### PR TITLE
added author authorized heading, lccn and wikidata qid to post45 hathitrust_post45fiction_metadata file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
This adds the fields:
```
author_authorized_heading - the authorized access point heading from id.loc.gov
author_lccn - the LCCN identifier from id.loc.gov
author_wikidata_qid - the Wikidata Q number from Wikidata SPARQL service
hathi_rights - the rights code from Hathi for that Hathi record id 
author_marc - the Author names pulled from the 1xx/7xx field
```

to `hathitrust_post45fiction_metadata.tsv`

Stats: We are at about 92% controlled for names to LCCN identifiers, 5800 of the 75,000 remain with no author identifier. we're at 71% for having a wikidata qid for the authors with 54,160 names matches to wikidata.
