### PR TITLE
tweak approch, increase matching percent a few points

### DIFF
--- a/major_literary_prizes/major_literary_prizes-winners_judges.tsv
+++ b/major_literary_prizes/major_literary_prizes-winners_judges.tsv
@@ -2,7 +2,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 922	Inge Judd	Inge	Judd					unknown						judge	National Book Foundation	National Book Award	1981	poetry	book	10000.0	The Need To Hold Still: Poems
 922	Inge Judd	Inge	Judd					unknown						judge	National Book Foundation	National Book Award	1982	prose	book	10000.0	Rabbit Is Rich & So Long, See You Tomorrow
 922	Inge Judd	Inge	Judd					unknown						judge	National Book Foundation	National Book Award	1982	prose	book	10000.0	Rabbit Is Rich & So Long, See You Tomorrow
-1891	Reuben Bercovitch	Reuben	Bercovitch					unknown						winner	PEN America	Hemingway Award for Debut Novel	1979	prose	book	10000.0	Hasen
+1891	Reuben Bercovitch	Reuben	Bercovitch			11295941	n85265603	unknown						winner	PEN America	Hemingway Award for Debut Novel	1979	prose	book	10000.0	Hasen
 1807	Pauline Hanson	Pauline	Hanson					unknown						winner	American Academy of Arts and Letters	Arts and Letters Awards	1972	no genre	career	10000.0	
 1032	Jean Valentine	Jean	Valentine	Q14948838	Jean Valentine	161665325	n79027012	female	Radcliffe College	graduate				winner	Yale University	Bollingen Prize for Poetry	2017	poetry	career	10000.0	
 123	Andrea Lawlor	Andrea	Lawlor	Q97930223	Andrea Lawlor	26865645	no2008023022	nonbinary/they		graduate	University of Massachusetts, Amherst			winner	Whiting Foundation	Whiting Award	2020	no genre	career	50000.0	
@@ -38,13 +38,13 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 617	E. L. Doctorow	E. L.	Doctorow	Q335232	E. L. Doctorow	14768905	n79021656	male						winner	National Book Foundation	National Book Award	1986	prose	book	10000.0	World's Fair
 2192	T. Coraghessan Boyle	T. Coraghessan	Boyle	Q786526	T. Coraghessan Boyle	14796817	n78072648	male		graduate	University of Iowa	758		winner	PEN America	Faulkner Award for Fiction	1988	prose	book	15000.0	World's End
 2031	Russell Banks	Russell	Banks	Q665144	Russell Banks	66487364	n79131992	male						judge	PEN America	Faulkner Award for Fiction	1988	prose	book	15000.0	World's End
-545	David St John	David	St John	Q5240011	David St John Thomas	60321473	n50010162	male		graduate	University of Iowa	3483		judge	Academy of American Poets	Lenore Marshall Poetry Prize	2012	poetry	book	25000.0	World Tree
+545	David St John	David	St John	Q5240013	David St. John	11122111	n79058424	male		graduate	University of Iowa	3483		judge	Academy of American Poets	Lenore Marshall Poetry Prize	2012	poetry	book	25000.0	World Tree
 547	David Wojahn	David	Wojahn	Q5241252	David Wojahn	68953589	n81104795	male		graduate	University of Arizona			winner	Academy of American Poets	Lenore Marshall Poetry Prize	2012	poetry	book	25000.0	World Tree
 471	Daniel Hoffman	Daniel	Hoffman	Q5217498	Daniel Hoffman	299139437	n79058587	male	Columbia University	graduate				judge	National Book Foundation	National Book Award	1959	poetry	book	10000.0	Words For The Wind: Poems Of Theodore Roethke
 1869	Randall Jarrell	Randall	Jarrell	Q972676	Randall Jarrell	100256034	n79076730	male		graduate				judge	National Book Foundation	National Book Award	1959	poetry	book	10000.0	Words For The Wind: Poems Of Theodore Roethke
 1980	Robert Penn Warren	Robert Penn	Warren	Q312720	Robert Penn Warren	61553765	n78091524	male		graduate				judge	National Book Foundation	National Book Award	1959	poetry	book	10000.0	Words For The Wind: Poems Of Theodore Roethke
 2213	Theodore Roethke	Theodore	Roethke	Q1151763	Theodore Roethke	24682652	n79060436	male		graduate				winner	National Book Foundation	National Book Award	1959	poetry	book	10000.0	Words For The Wind: Poems Of Theodore Roethke
-1139	John Holmes	John	Holmes					male						judge	National Book Foundation	National Book Award	1959	poetry	book	10000.0	Words For The Wind: Poems Of Theodore Roethke
+1139	John Holmes	John	Holmes	Q6239670	John Holmes	85144928712954440017	n85274137	male						judge	National Book Foundation	National Book Award	1959	poetry	book	10000.0	Words For The Wind: Poems Of Theodore Roethke
 1536	Mark Sarvas	Mark	Sarvas	Q6769591	Mark Sarvas	107051357	n2008006863	male		graduate	Bennington College			judge	Center for Fiction	First Novel Prize	2009	prose	book	15000.0	Woodsburner
 1164	John Pipkin	John	Pipkin	Q22279683	John Pipkin	48701179	n2008050822	male		graduate				winner	Center for Fiction	First Novel Prize	2009	prose	book	15000.0	Woodsburner
 384	Chris Sorrentino	Chris	Sorrentino					male						judge	Center for Fiction	First Novel Prize	2009	prose	book	15000.0	Woodsburner
@@ -66,7 +66,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1918	Richard Wilbur	Richard	Wilbur	Q1333582	Richard Wilbur	14804371	n79007244	male	Harvard University	graduate				judge	National Book Foundation	National Book Award	1991	poetry	book	10000.0	What Work Is
 1962	Robert Hass	Robert	Hass	Q370513	Robert Hass	26975	n83039272	male	Stanford University	graduate				winner	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	2013	prose	book	15000.0	What Light Can Do: Essays on Art, Imagination, and the Natural World
 1530	Mark Kramer	Mark	Kramer	Q110903764	Mark Kramer			male	Columbia University	graduate				judge	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	2013	prose	book	15000.0	What Light Can Do: Essays on Art, Imagination, and the Natural World
-1960	Robert Gottlieb	Robert	Gottlieb	Q16887967	Robert Grötzsch	52325333	nr2001000942	male	Columbia University					judge	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	2013	prose	book	15000.0	What Light Can Do: Essays on Art, Imagination, and the Natural World
+1960	Robert Gottlieb	Robert	Gottlieb	Q2157324	Robert Gottlieb	115258333	n96029097	male	Columbia University					judge	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	2013	prose	book	15000.0	What Light Can Do: Essays on Art, Imagination, and the Natural World
 2187	Sven Birkerts	Sven	Birkerts	Q2370989	Sven Birkerts	2502462	n86115535	male						judge	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	2013	prose	book	15000.0	What Light Can Do: Essays on Art, Imagination, and the Natural World
 1522	Mark Athitakis	Mark	Athitakis					male						judge	Kirkus Review	Kirkus Prize	2017	prose	book	50000.0	What It Means When A Man Falls From The Sky
 883	Henry Seidel Canby	Henry Seidel	Canby	Q15501218	Henry Seidel Canby	7559111	n50051945	male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1944	poetry	book	15000.0	Western Star
@@ -76,7 +76,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 392	Christopher Coake	Christopher	Coake	Q5112119	Christopher Coake	29812997	n2004032675	male		graduate	Ohio State University			winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2006	prose	book	25000.0	We'Re In Trouble
 230	Benjamine Alire Saenz	Benjamine Alire	Saenz					male		graduate	University of Texas, El Paso			judge	PEN America	Hemingway Award for Debut Novel	2014	prose	book	10000.0	We Need New Names
 2079	Scott Turow	Scott	Turow	Q451136	Scott Turow	106980468	n86032292	male	Stanford University	graduate			Stegner	judge	PEN America	Hemingway Award for Debut Novel	2014	prose	book	10000.0	We Need New Names
-1484	Manuel Muñoz	Manuel	Muñoz					male	Harvard University, Cornell University	graduate	Cornell University			judge	PEN America	Faulkner Award for Fiction	2014	prose	book	15000.0	We Are All Completely Beside Ourselves
+1484	Manuel Muñoz	Manuel	Muñoz	Q15439348	Manuel Muñoz	25801478	n2006073516	male	Harvard University, Cornell University	graduate	Cornell University			judge	PEN America	Faulkner Award for Fiction	2014	prose	book	15000.0	We Are All Completely Beside Ourselves
 1471	Madison Smart Bell	Madison Smart	Bell					male	Princeton University	graduate				judge	PEN America	Faulkner Award for Fiction	2014	prose	book	15000.0	We Are All Completely Beside Ourselves
 1988	Robert Wrigley	Robert	Wrigley	Q7351272	Robert Wrigley	52952040	n78090918	male		graduate	University of Montana			judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2003	poetry	book	100000.0	Waterborne
 1982	Robert Pinsky	Robert	Pinsky	Q588807	Robert Pinsky	79069348	n83039273	male	Stanford University	graduate			Stegner	judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2003	poetry	book	100000.0	Waterborne
@@ -113,7 +113,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2344	Wilbur L. Cross	Wilbur L.	Cross					male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1945	poetry	book	15000.0	V-Letter And Other Poems
 1263	Karl Shapiro	Karl	Shapiro	Q2906282	Karl Shapiro	109257053	n79021704	male						winner	Columbia University	Pulitzer Prize	1945	poetry	book	15000.0	V-Letter And Other Poems
 1430	Louis Untermeyer	Louis	Untermeyer	Q1872015	Louis Untermeyer	39541598	n79054344	male						judge	Columbia University	Pulitzer Prize	1945	poetry	book	15000.0	V-Letter And Other Poems
-2354	William Alfred	William	Alfred					male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1973	poetry	book	15000.0	Up Country
+2354	William Alfred	William	Alfred	Q8004294	William Alfred	53072398	n83208234	male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1973	poetry	book	15000.0	Up Country
 1429	Louis Simpson	Louis	Simpson	Q1871997	Louis Simpson	7509913	n50023694	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1973	poetry	book	15000.0	Up Country
 1904	Richard Howard	Richard	Howard	Q2636383	Richard Howard	73940071	n79066341	male	Columbia University	graduate				winner	Columbia University	Pulitzer Prize	1970	poetry	book	15000.0	Untitled Subjects
 966	James Dickey	James	Dickey	Q1377013	James Dickey	109230203	n79043450	male						judge	Columbia University	Pulitzer Prize	1970	poetry	book	15000.0	Untitled Subjects
@@ -121,7 +121,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1933	Rigoberto González	Rigoberto	González	Q7333845	Rigoberto González	43620311	n98086894	male		graduate	University of Arizona			winner	Academy of American Poets	Lenore Marshall Poetry Prize	2014	poetry	book	25000.0	Unpeopled Eden
 1331	Kwame Dawes	Kwame	Dawes	Q6450075	Kwame Dawes	65093267	no95021730	male		graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	2014	poetry	book	25000.0	Unpeopled Eden
 1925	Rick Demarinis	Rick	Demarinis	Q204668	Rick DeMarinis	17221574	n85244651	male						winner	University of Pittsburg Press	Drue Heinz Literature Prize	1986	prose	book	15000.0	Under The Wheat
-477	Daniel Stern	Daniel	Stern	Q253453	Marie d'Agoult	186930001	n85117413	male						winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1990	prose	book	10000.0	Twice Told Tales
+477	Daniel Stern	Daniel	Stern	Q5218842	Daniel Stern	108290713	n80003985	male						winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1990	prose	book	10000.0	Twice Told Tales
 1429	Louis Simpson	Louis	Simpson	Q1871997	Louis Simpson	7509913	n50023694	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1975	poetry	book	15000.0	Turtle Island
 998	James Wright	James	Wright	Q6145850	James Wright	12322205	n50028672	male		graduate				judge	Columbia University	Pulitzer Prize	1975	poetry	book	15000.0	Turtle Island
 786	Gary Snyder	Gary	Snyder	Q315963	Gary Snyder	68944804	n79150347	male						winner	Columbia University	Pulitzer Prize	1975	poetry	book	15000.0	Turtle Island
@@ -142,7 +142,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2381	William Stafford	William	Stafford	Q2580632	William Stafford	110362789	n50023886	male		graduate				winner	National Book Foundation	National Book Award	1963	poetry	book	10000.0	Traveling Through The Dark
 1884	Reed Whittemore	Reed	Whittemore	Q7306708	Reed Whittemore	2502914	n50016190	male	Yale University					judge	National Book Foundation	National Book Award	1963	poetry	book	10000.0	Traveling Through The Dark
 2005	Rolfe Humphries	Rolfe	Humphries	Q7360825	Rolfe Humphries	79410283	n50034126	male						judge	National Book Foundation	National Book Award	1963	poetry	book	10000.0	Traveling Through The Dark
-2291	Van Jordan	Van	Jordan					male		graduate	Warren Wilson College			judge	National Book Foundation	National Book Award	2009	poetry	book	10000.0	Transcendental Studies: A Trilogy
+2291	Van Jordan	Van	Jordan	Q4648474	A. Van Jordan	2121769	no2001077639	male		graduate	Warren Wilson College			judge	National Book Foundation	National Book Award	2009	poetry	book	10000.0	Transcendental Studies: A Trilogy
 1317	Kevin Young	Kevin	Young	Q6397805	Kevin Young	9074736	n94048090	male	Harvard University, Brown University, Stanford University	graduate	Brown University		Stegner	judge	National Book Foundation	National Book Award	2009	poetry	book	10000.0	Transcendental Studies: A Trilogy
 1300	Keith Waldrop	Keith	Waldrop	Q6385175	Keith Waldrop	92823764	n50020091	male		graduate				winner	National Book Foundation	National Book Award	2009	poetry	book	10000.0	Transcendental Studies: A Trilogy
 2239	Thorp Menn	Thorp	Menn					male						judge	National Book Foundation	National Book Award	1971	poetry	book	10000.0	To See, To Take: Poems
@@ -156,12 +156,12 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 354	Charles Johnson	Charles	Johnson	Q1065092	Charles Johnson	4098150567615706370002	n86836122	male		graduate				judge	Columbia University	Pulitzer Prize	2010	prose	book	15000.0	Tinkers
 70	Alfred Kreynborg	Alfred	Kreynborg					male						judge	Columbia University	Pulitzer Prize	1961	poetry	book	15000.0	Times Three: Selected Verse From Three Decades
 1430	Louis Untermeyer	Louis	Untermeyer	Q1872015	Louis Untermeyer	39541598	n79054344	male						judge	Columbia University	Pulitzer Prize	1961	poetry	book	15000.0	Times Three: Selected Verse From Three Decades
-545	David St John	David	St John	Q5240011	David St John Thomas	60321473	n50010162	male		graduate	University of Iowa	3483		judge	National Book Foundation	National Book Award	2007	poetry	book	10000.0	Time And Materials: Poems, 1997-2005
+545	David St John	David	St John	Q5240013	David St. John	11122111	n79058424	male		graduate	University of Iowa	3483		judge	National Book Foundation	National Book Award	2007	poetry	book	10000.0	Time And Materials: Poems, 1997-2005
 2305	Vijay Seshadri	Vijay	Seshadri	Q7929205	Vijay Seshadri	1733248	n96038513	male	Columbia University	graduate	Columbia University			judge	National Book Foundation	National Book Award	2007	poetry	book	10000.0	Time And Materials: Poems, 1997-2005
 1962	Robert Hass	Robert	Hass	Q370513	Robert Hass	26975	n83039272	male	Stanford University	graduate				winner	National Book Foundation	National Book Award	2007	poetry	book	10000.0	Time And Materials: Poems, 1997-2005
 1962	Robert Hass	Robert	Hass	Q370513	Robert Hass	26975	n83039272	male	Stanford University	graduate				winner	Columbia University	Pulitzer Prize	2008	poetry	book	15000.0	Time And Materials: Poems, 1997-2005
 362	Charles Simic	Charles	Simic	Q722555	Charles Simic	22044	n80043344	male						judge	National Book Foundation	National Book Award	2007	poetry	book	10000.0	Time And Materials: Poems, 1997-2005
-1192	Jonathan Strong	Jonathan	Strong					male	Harvard University					winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1970	prose	book	10000.0	Tike And Five Stories
+1192	Jonathan Strong	Jonathan	Strong			63075539	n87893203	male	Harvard University					winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1970	prose	book	10000.0	Tike And Five Stories
 260	Bob Shacochis	Bob	Shacochis	Q4933931	Bob Shacochis	44315563	n84105588	male		graduate	University of Iowa	1389		judge	National Book Foundation	National Book Award	2002	prose	book	10000.0	Three Junes
 548	David Wong Louie	David	Wong Louie	Q5241270	David Wong Louie	93957051	n90720357	male		graduate	University of Iowa	1308		judge	National Book Foundation	National Book Award	2002	prose	book	10000.0	Three Junes
 1025	Jay McInery	Jay	McInery					male		graduate	Syracuse University			judge	National Book Foundation	National Book Award	2002	prose	book	10000.0	Three Junes
@@ -184,8 +184,8 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 901	Horace Gregory	Horace	Gregory	Q13891091	Horace Gregory	110610574	n50031474	male						judge	National Book Foundation	National Book Award	1957	poetry	book	10000.0	Things Of This World
 1430	Louis Untermeyer	Louis	Untermeyer	Q1872015	Louis Untermeyer	39541598	n79054344	male						judge	National Book Foundation	National Book Award	1957	poetry	book	10000.0	Things Of This World
 1430	Louis Untermeyer	Louis	Untermeyer	Q1872015	Louis Untermeyer	39541598	n79054344	male						judge	Columbia University	Pulitzer Prize	1957	poetry	book	15000.0	Things Of This World
-1831	Peter Taylor	Peter	Taylor					male						judge	National Book Foundation	National Book Award	1957	poetry	book	10000.0	Things Of This World
-1846	Philip Williams	Philip	Williams					male		graduate	Washington University			winner	Claremont Graduate University	Kate Tufts Discovery Award 	2017	poetry	book	10000.0	Thief In The Interior
+1831	Peter Taylor	Peter	Taylor	Q7177265	Peter Taylor	110914595	n82057802	male						judge	National Book Foundation	National Book Award	1957	poetry	book	10000.0	Things Of This World
+1846	Philip Williams	Philip	Williams	Q60607911	Philip Williams			male		graduate	Washington University			winner	Claremont Graduate University	Kate Tufts Discovery Award 	2017	poetry	book	10000.0	Thief In The Interior
 2205	Terrance Hayes	Terrance	Hayes	Q7703264	Terrance Hayes	19313000	no99042009	male		graduate	University of Pittsburgh			judge	Claremont Graduate University	Kate Tufts Discovery Award 	2017	poetry	book	10000.0	Thief In The Interior
 283	Brian Kim Stefans	Brian Kim	Stefans	Q4964351	Brian Kim Stefans	265064436	n2002029377	male	Brown University	graduate	Brown University			judge	Claremont Graduate University	Kate Tufts Discovery Award 	2017	poetry	book	10000.0	Thief In The Interior
 587	Don Share	Don	Share	Q5293504	Don Share	55730698	n88642863	male	Brown University	graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	2017	poetry	book	10000.0	Thief In The Interior
@@ -213,7 +213,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1755	Oscar Hijuelos	Oscar	Hijuelos	Q579475	Oscar Hijuelos	61601967	n82120993	male		graduate				judge	PEN America	Hemingway Award for Debut Novel	2013	prose	book	10000.0	The Yellow Birds
 436	Craig Nova	Craig	Nova	Q5181283	Craig Nova	20293024	n82031955	male						judge	PEN America	Hemingway Award for Debut Novel	2013	prose	book	10000.0	The Yellow Birds
 1037	Jefferson Fletcher	Jefferson	Fletcher					male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1939	prose	book	15000.0	The Yearling
-1213	Joseph Krutch	Joseph	Krutch					male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1939	prose	book	15000.0	The Yearling
+1213	Joseph Krutch	Joseph	Krutch	Q291183	Joseph Wood Krutch	49274843	n80007874	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1939	prose	book	15000.0	The Yearling
 1971	Robert Lovett	Robert	Lovett					male	Harvard University					judge	Columbia University	Pulitzer Prize	1939	prose	book	15000.0	The Yearling
 994	James Tate	James	Tate	Q531155	James Tate	57136	n78094025	male		graduate	University of Iowa	345		winner	National Book Foundation	National Book Award	1994	poetry	book	10000.0	The Worshipful Company Of Fletchers: Poems
 783	Garrett Hongo	Garrett	Hongo	Q5523900	Garrett Hongo	59947817	n79036313	male		graduate	Univeristy of California, Irvine			judge	National Book Foundation	National Book Award	1994	poetry	book	10000.0	The Worshipful Company Of Fletchers: Poems
@@ -224,7 +224,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 362	Charles Simic	Charles	Simic	Q722555	Charles Simic	22044	n80043344	male						winner	Columbia University	Pulitzer Prize	1990	poetry	book	15000.0	The World Doesn't End
 1142	John Irving	John	Irving	Q310379	John Irving	108238891	n79135330	male		graduate	University of Iowa	86		winner	National Book Foundation	National Book Award	1980	prose	book	10000.0	The World According To Garp
 2403	Yusef Komunyakaa	Yusef	Komunyakaa	Q2601996	Yusef Komunyakaa	32006129	n82203462	male		graduate	Univeristy of California, Irvine			judge	Columbia University	Pulitzer Prize	2000	poetry	book	15000.0	The World    
-46	Alan Williamson	Alan	Williamson					male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	2000	poetry	book	15000.0	The World    
+46	Alan Williamson	Alan	Williamson	Q104493595	Alan Williamson			male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	2000	poetry	book	15000.0	The World    
 302	C. K. Williams	C. K.	Williams	Q2930440	C. K. Williams	112923690	n50016812	male	University of Pennsylvania					winner	Columbia University	Pulitzer Prize	2000	poetry	book	15000.0	The World    
 2312	W. D. Snodgrass	W. D.	Snodgrass	Q1334959	W. D. Snodgrass	117357452	n50014773	male		graduate	University of Iowa	62		judge	National Book Foundation	National Book Award	1961	poetry	book	10000.0	The Woman At The Washington Zoo: Poems And Translations
 1326	Kimon Friar	Kimon	Friar	Q6410221	Kimon Friar	14997681	n50024075	male		graduate				judge	National Book Foundation	National Book Award	1961	poetry	book	10000.0	The Woman At The Washington Zoo: Poems And Translations
@@ -239,7 +239,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1947	Robert Coates	Robert	Coates	Q9069789	Robert M. Coates	34583723	n84231754	male	Yale University	graduate				judge	National Book Foundation	National Book Award	1961	prose	book	10000.0	The Waters Of Kronos
 194	Arthur Mizener	Arthur	Mizener	Q16012130	Arthur Mizener	108230775	n79064702	male	Princeton University, Harvard University	graduate				judge	National Book Foundation	National Book Award	1961	prose	book	10000.0	The Waters Of Kronos
 429	Conrad Richter	Conrad	Richter	Q732568	Conrad Richter	46779708	n50053399	male						winner	National Book Foundation	National Book Award	1961	prose	book	10000.0	The Waters Of Kronos
-49	Albert Guerard	Albert	Guerard					male	Stanford University, Harvard University	graduate				judge	National Book Foundation	National Book Award	1958	prose	book	10000.0	The Wapshot Chronicle
+49	Albert Guerard	Albert	Guerard	Q4710533	Albert J. Guerard	67760832	n80051525	male	Stanford University, Harvard University	graduate				judge	National Book Foundation	National Book Award	1958	prose	book	10000.0	The Wapshot Chronicle
 2372	William Maxwell	William	Maxwell	Q1541271	William Keepers Maxwell, Jr.	114674264	n79065705	male	Harvard University	graduate				judge	National Book Foundation	National Book Award	1958	prose	book	10000.0	The Wapshot Chronicle
 2295	Vanwyck Brooks	Vanwyck	Brooks					male	Harvard University					judge	National Book Foundation	National Book Award	1958	prose	book	10000.0	The Wapshot Chronicle
 748	Francis Steegmuller	Francis	Steegmuller	Q5482502	Francis Steegmuller	79045713	n79059809	male	Columbia University					judge	National Book Foundation	National Book Award	1958	prose	book	10000.0	The Wapshot Chronicle
@@ -247,11 +247,11 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 70	Alfred Kreynborg	Alfred	Kreynborg					male						judge	Columbia University	Pulitzer Prize	1954	poetry	book	15000.0	The Waking
 861	Harris Fletcher	Harris	Fletcher	Q5664899	Harris Fletcher	5028590	n50003543	male		graduate				judge	Columbia University	Pulitzer Prize	1954	prose	book	15000.0	The Waking
 2213	Theodore Roethke	Theodore	Roethke	Q1151763	Theodore Roethke	24682652	n79060436	male		graduate				winner	Columbia University	Pulitzer Prize	1954	poetry	book	15000.0	The Waking
-704	Eric Kelly	Eric	Kelly					male	Dartmouth College					judge	Columbia University	Pulitzer Prize	1954	prose	book	15000.0	The Waking
+704	Eric Kelly	Eric	Kelly	Q5387228	Eric P. Kelly	79366435	n50048142	male	Dartmouth College					judge	Columbia University	Pulitzer Prize	1954	prose	book	15000.0	The Waking
 1430	Louis Untermeyer	Louis	Untermeyer	Q1872015	Louis Untermeyer	39541598	n79054344	male						judge	Columbia University	Pulitzer Prize	1954	poetry	book	15000.0	The Waking
 700	Eric Banks	Eric	Banks					male						judge	Columbia University	Pulitzer Prize	2017	prose	book	15000.0	The Underground Railroad
 2211	Tgeronimo Johnson	Tgeronimo	Johnson					male	Stanford University	graduate	University of Iowa	2724	Stegner	judge	National Book Foundation	National Book Award	2016	prose	book	10000.0	The Underground Railroad
-967	James English	James	English					male	University of Chicago, Stanford University	graduate				judge	National Book Foundation	National Book Award	2016	prose	book	10000.0	The Underground Railroad
+967	James English	James	English	Q4357464	Jon English	33929979	n2008041677	male	University of Chicago, Stanford University	graduate				judge	National Book Foundation	National Book Award	2016	prose	book	10000.0	The Underground Railroad
 425	Colson Whitehead	Colson	Whitehead	Q509662	Colson Whitehead	69151887	n98027019	male	Harvard University					winner	National Book Foundation	National Book Award	2016	prose	book	10000.0	The Underground Railroad
 425	Colson Whitehead	Colson	Whitehead	Q509662	Colson Whitehead	69151887	n98027019	male	Harvard University					winner	Columbia University	Pulitzer Prize	2017	prose	book	15000.0	The Underground Railroad
 1131	John Guare	John	Guare	Q320556	John Guare	71506879	n80065728	male		graduate	Yale University			judge	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2016	prose	book	10000.0	The Tsar Of Love And Techno
@@ -286,19 +286,19 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1037	Jefferson Fletcher	Jefferson	Fletcher					male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1933	prose	book	15000.0	The Store
 1971	Robert Lovett	Robert	Lovett					male	Harvard University					judge	Columbia University	Pulitzer Prize	1933	prose	book	15000.0	The Store
 51	Albert Paine	Albert	Paine	Q4710951	Albert Paine	24731419	n80089241	male						judge	Columbia University	Pulitzer Prize	1933	prose	book	15000.0	The Store
-2235	Thomas Stribling	Thomas	Stribling					male						winner	Columbia University	Pulitzer Prize	1933	prose	book	15000.0	The Store
+2235	Thomas Stribling	Thomas	Stribling	Q386244	Thomas Sigismund Stribling	77114256	n50011482	male						winner	Columbia University	Pulitzer Prize	1933	prose	book	15000.0	The Store
 354	Charles Johnson	Charles	Johnson	Q1065092	Charles Johnson	4098150567615706370002	n86836122	male		graduate				judge	Columbia University	Pulitzer Prize	1995	prose	book	15000.0	The Stone Diaries
 1097	Joel Conarroe	Joel	Conarroe					male		graduate				judge	Columbia University	Pulitzer Prize	1995	prose	book	15000.0	The Stone Diaries
 790	Gene Seymour	Gene	Seymour					male						judge	Kirkus Review	Kirkus Prize	2016	prose	book	50000.0	The Sport Of Kings
 515	David Guterson	David	Guterson	Q1174627	David Guterson	84055110	n88159394	male		graduate	University of Washington			judge	University of Pittsburg Press	Drue Heinz Literature Prize	2014	prose	book	15000.0	The Spirit Bird
 1312	Kent Nelson	Kent	Nelson	Q6391843	Kent Nelson	34499341	n78041900	male	Yale University	graduate				winner	University of Pittsburg Press	Drue Heinz Literature Prize	2014	prose	book	15000.0	The Spirit Bird
 730	F. D. Reeve	F. D.	Reeve	Q5423738	F. D. Reeve	110961050	n80083588	male	Princeton University, Columbia University	graduate				judge	National Book Foundation	National Book Award	1977	prose	book	10000.0	The Spectator Bird
-801	George Elliott	George	Elliott					male		graduate				judge	National Book Foundation	National Book Award	1977	prose	book	10000.0	The Spectator Bird
+801	George Elliott	George	Elliott	Q5538961	George Elliott	105871072	n86150102	male		graduate				judge	National Book Foundation	National Book Award	1977	prose	book	10000.0	The Spectator Bird
 2320	Wallace Stegner	Wallace	Stegner	Q203460	Wallace Stegner	110195864	n79021163	male		graduate				winner	National Book Foundation	National Book Award	1977	prose	book	10000.0	The Spectator Bird
 717	Erskine Caldwell	Erskine	Caldwell	Q310464	Erskine Caldwell	46758305	n78095661	male						judge	National Book Foundation	National Book Award	1977	prose	book	10000.0	The Spectator Bird
 1752	Orville Prescott	Orville	Prescott	Q7105248	Orville Prescott	237553275	n50028227	male						judge	National Book Foundation	National Book Award	1977	prose	book	10000.0	The Spectator Bird
 2187	Sven Birkerts	Sven	Birkerts	Q2370989	Sven Birkerts	2502462	n86115535	male						judge	University of Pittsburg Press	Drue Heinz Literature Prize	2012	prose	book	15000.0	The Source Of Life And Other Stories
-1981	Robert Phillips	Robert	Phillips					male	Yale University	graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	1988	poetry	book	25000.0	The Sisters: New & Selected Poems
+1981	Robert Phillips	Robert	Phillips	Q7348886	Robert Phillips	108961346	n78096860	male	Yale University	graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	1988	poetry	book	25000.0	The Sisters: New & Selected Poems
 2366	William Jay Smith	William Jay	Smith	Q4355736	William Jay Smith	1176890	n79042253	male		graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	1988	poetry	book	25000.0	The Sisters: New & Selected Poems
 297	Bruce Weigl	Bruce	Weigl	Q4978445	Bruce Weigl	115150664	n78072493	male		graduate				judge	National Book Foundation	National Book Award	2003	poetry	book	10000.0	The Singing
 500	David Baker	David	Baker	Q1173633	David Baker	103248740	n82056913	male		graduate				judge	National Book Foundation	National Book Award	2003	poetry	book	10000.0	The Singing
@@ -326,7 +326,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1741	Norman Rush	Norman	Rush	Q1215607	Norman Rush	93387650	n85220366	male						judge	PEN America	Jean Stein Book Award	2017	no genre	book	75000.0	The Return: Fathers, Sons, And The Land In Between
 769	Frederick Buechner	Frederick	Buechner	Q1452807	Frederick Buechner	66589484	n80050015	male	Princeton University					winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1959	prose	book	10000.0	The Return Of Ansel Gibbs
 314	Carlos Baker	Carlos	Baker	Q5041809	Carlos Baker	107027003	n50020883	male	Dartmouth College, Harvard University, Princeton University	graduate				judge	Columbia University	Pulitzer Prize	1955	prose	book	15000.0	The Reivers
-745	Francis Brown	Francis	Brown					male	Dartmouth College, Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1955	prose	book	15000.0	The Reivers
+745	Francis Brown	Francis	Brown	Q60150800	Francis Brown	57461376	n50039648	male	Dartmouth College, Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1955	prose	book	15000.0	The Reivers
 927	Irwin Edman	Irwin	Edman					male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1955	prose	book	15000.0	The Reivers
 2361	William Faulkner	William	Faulkner	Q38392	William Faulkner	39376770	n79003304	male						winner	Columbia University	Pulitzer Prize	1955	prose	book	15000.0	The Reivers
 61	Alexander Chee	Alexander	Chee	Q4718581	Alexander Chee	162709698	n2001037216	male		graduate	University of Iowa	2149		judge	University of Pittsburg Press	Drue Heinz Literature Prize	2020	prose	book	15000.0	The Prince Of Mournful Thoughts And Other Stories
@@ -337,25 +337,25 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1057	Jericho Brown	Jericho	Brown	Q15440076	Jericho Brown	317141438	no2009022322	male		graduate	University of New Orleans			judge	National Book Foundation	National Book Award	2016	poetry	book	10000.0	The Performance Of Becoming Human
 467	Daniel Borzutzky	Daniel	Borzutzky	Q28370094	Daniel Borzutzky			male		graduate	School of Art Institute of Chicago			winner	National Book Foundation	National Book Award	2016	poetry	book	10000.0	The Performance Of Becoming Human
 1523	Mark Bibbins	Mark	Bibbins	Q16197606	Mark Bibbins			male		graduate	New School for Social Research			judge	National Book Foundation	National Book Award	2016	poetry	book	10000.0	The Performance Of Becoming Human
-1035	Jeff Talarigo	Jeff	Talarigo					male						winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2005	prose	book	10000.0	The Pearl Diver
+1035	Jeff Talarigo	Jeff	Talarigo			79552605	n2003047853	male						winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2005	prose	book	10000.0	The Pearl Diver
 2149	Stephenl Carter	Stephenl	Carter					male	Stanford University, Yale University	graduate				judge	Columbia University	Pulitzer Prize	2019	prose	book	15000.0	The Overstory
 1362	Lawrence Buell	Lawrence	Buell	Q3219886	Lawrence Buell	108310309	n80115780	male	Princeton University, Cornell University	graduate				judge	Columbia University	Pulitzer Prize	2019	prose	book	15000.0	The Overstory
 1646	Michael Wood	Michael	Wood	Q209394	Michael Wood	22323391	n87115377	male		graduate				judge	Columbia University	Pulitzer Prize	2019	prose	book	15000.0	The Overstory
 1911	Richard Powers	Richard	Powers	Q638179	Richard Powers	113865419	n85007982	male		graduate				winner	Columbia University	Pulitzer Prize	2019	prose	book	15000.0	The Overstory
 15	Adam Johnson	Adam	Johnson	Q4679309	Adam Johnson	119126256	n2001039608	male	Stanford University	graduate	McNeese State University		Stegner	winner	Columbia University	Pulitzer Prize	2013	prose	book	15000.0	The Orphan Master's Son
-1120	John Dudley	John	Dudley					male	Cornell University	graduate				judge	Columbia University	Pulitzer Prize	2013	prose	book	15000.0	The Orphan Master's Son
+1120	John Dudley	John	Dudley	Q6230259	John Dudley			male	Cornell University	graduate				judge	Columbia University	Pulitzer Prize	2013	prose	book	15000.0	The Orphan Master's Son
 628	Edmund Fuller	Edmund	Fuller	Q5339483	Edmund Fuller	111280970	n50023712	male						judge	Columbia University	Pulitzer Prize	1973	prose	book	15000.0	The Optimist's Daughter
 841	Guy Davenport	Guy	Davenport	Q506069	Guy Davenport	36933869	n50036535	male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1973	prose	book	15000.0	The Optimist's Daughter
 891	Herman Kogan	Herman	Kogan	Q15489169	Herman Kogan	50470157	n50042954	male	University of Chicago					judge	Columbia University	Pulitzer Prize	1973	prose	book	15000.0	The Optimist's Daughter
-176	Anthony Wallace	Anthony	Wallace					male		graduate				winner	University of Pittsburg Press	Drue Heinz Literature Prize	2013	prose	book	15000.0	The Old Priest
+176	Anthony Wallace	Anthony	Wallace			305018873	n2013042671	male		graduate				winner	University of Pittsburg Press	Drue Heinz Literature Prize	2013	prose	book	15000.0	The Old Priest
 2023	Roy Couden	Roy	Couden					male						judge	Columbia University	Pulitzer Prize	1953	prose	book	15000.0	The Old Man And The Sea
-704	Eric Kelly	Eric	Kelly					male	Dartmouth College					judge	Columbia University	Pulitzer Prize	1953	prose	book	15000.0	The Old Man And The Sea
+704	Eric Kelly	Eric	Kelly	Q5387228	Eric P. Kelly	79366435	n50048142	male	Dartmouth College					judge	Columbia University	Pulitzer Prize	1953	prose	book	15000.0	The Old Man And The Sea
 712	Ernest Hemingway	Ernest	Hemingway	Q23434	Ernest Hemingway	97006051	n78078534	male						winner	Columbia University	Pulitzer Prize	1953	prose	book	15000.0	The Old Man And The Sea
 1122	John Edgar Wideman	John Edgar	Wideman	Q688739	John Edgar Wideman	110405033	n82231445	male	University of Pennsylvania	graduate	University of Iowa	missing		winner	PEN America	Faulkner Award for Fiction	1984	prose	book	15000.0	The Old Forest And Other Stories
 1895	Richard Bausch	Richard	Bausch	Q3430510	Richard Bausch	263596254	n80019827	male		graduate	University of Iowa	833		judge	PEN America	Faulkner Award for Fiction	1986	prose	book	15000.0	The Old Forest And Other Stories
-504	David Bradley	David	Bradley					male	University of Pennsylvania	graduate				judge	PEN America	Faulkner Award for Fiction	1984	prose	book	15000.0	The Old Forest And Other Stories
+504	David Bradley	David	Bradley	Q5231656	David Bradley	115793286	n80160307	male	University of Pennsylvania	graduate				judge	PEN America	Faulkner Award for Fiction	1984	prose	book	15000.0	The Old Forest And Other Stories
 1950	Robert Coover	Robert	Coover	Q1282338	Robert Coover	99874615	n80038251	male	University of Chicago	graduate				judge	PEN America	Faulkner Award for Fiction	1984	prose	book	15000.0	The Old Forest And Other Stories
-1831	Peter Taylor	Peter	Taylor					male						winner	PEN America	Faulkner Award for Fiction	1986	prose	book	15000.0	The Old Forest And Other Stories
+1831	Peter Taylor	Peter	Taylor	Q7177265	Peter Taylor	110914595	n82057802	male						winner	PEN America	Faulkner Award for Fiction	1986	prose	book	15000.0	The Old Forest And Other Stories
 700	Eric Banks	Eric	Banks					male						judge	Columbia University	Pulitzer Prize	2020	prose	book	15000.0	The Nickel Boys
 551	Davidl Ulin	Davidl	Ulin					male	University of Pennsylvania					judge	Kirkus Review	Kirkus Prize	2019	prose	book	50000.0	The Nickel Boys
 425	Colson Whitehead	Colson	Whitehead	Q509662	Colson Whitehead	69151887	n98027019	male	Harvard University					winner	Kirkus Review	Kirkus Prize	2019	prose	book	50000.0	The Nickel Boys
@@ -366,7 +366,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1870	Randall Kenan	Randall	Kenan	Q3930018	Randall Kenan	49355658	n87852434	male						judge	National Book Foundation	National Book Award	2004	prose	book	10000.0	The News From Paraguay
 125	Andrew Bacevich	Andrew	Bacevich	Q933939	Andrew Bacevich	90806835	n85352615	male	Princeton University	graduate				winner	Lannan Foundation	Lannan Award	2005	no genre	career	150000.0	The New American Militarism: How Americans Are Seduced By War
 1886	Reginald Gibbons	Reginald	Gibbons	Q7308709	Reginald Gibbons	32254905	n78009649	male	Princeton University, Stanford University	graduate			Stegner	judge	Academy of American Poets	Lenore Marshall Poetry Prize	2016	poetry	book	25000.0	The Nerve Of It: Poems New And Selected
-1981	Robert Phillips	Robert	Phillips					male	Yale University	graduate				judge	National Book Foundation	National Book Award	1981	poetry	book	10000.0	The Need To Hold Still: Poems
+1981	Robert Phillips	Robert	Phillips	Q7348886	Robert Phillips	108961346	n78096860	male	Yale University	graduate				judge	National Book Foundation	National Book Award	1981	poetry	book	10000.0	The Need To Hold Still: Poems
 1125	John Frederick Nimas	John Frederick	Nimas					male	University of Chicago	graduate				judge	National Book Foundation	National Book Award	1981	poetry	book	10000.0	The Need To Hold Still: Poems
 2281	Turner Cassity	Turner	Cassity	Q7855909	Turner Cassity	17269487	n50034386	male	Stanford University, Columbia University	graduate			Stegner	judge	National Book Foundation	National Book Award	1981	poetry	book	10000.0	The Need To Hold Still: Poems
 1117	John Ciardi	John	Ciardi	Q947519	John Ciardi	108198403	n79058347	male		graduate				judge	National Book Foundation	National Book Award	1981	poetry	book	10000.0	The Need To Hold Still: Poems
@@ -376,20 +376,20 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2381	William Stafford	William	Stafford	Q2580632	William Stafford	110362789	n50023886	male		graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	1977	poetry	book	25000.0	The Names Of The Lost
 888	Herbert Gold	Herbert	Gold	Q5734234	Herbert Gold	108304879	n79039596	male	Columbia University	graduate				judge	National Book Foundation	National Book Award	1962	prose	book	10000.0	The Moviegoer
 1541	Mark Van Doren	Mark	Van Doren	Q975491	Mark Van Doren	12331775	n79100719	male	Columbia University	graduate				judge	National Book Foundation	National Book Award	1962	prose	book	10000.0	The Moviegoer
-1390	Lewis Gannett	Lewis	Gannett	Q6536574	Lewis Gannett			male	Harvard University					judge	National Book Foundation	National Book Award	1962	prose	book	10000.0	The Moviegoer
+1390	Lewis Gannett	Lewis	Gannett	Q62224679	Lewis Gannett	11462821	n90622248	male	Harvard University					judge	National Book Foundation	National Book Award	1962	prose	book	10000.0	The Moviegoer
 2317	Walker Percy	Walker	Percy	Q176909	Walker Percy	29539039	n80030460	male						winner	National Book Foundation	National Book Award	1962	prose	book	10000.0	The Moviegoer
 1103	John Ashbery	John	Ashbery	Q29418	John Ashbery	100001869	n79059269	male	Harvard University, Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1981	poetry	book	15000.0	The Morning Of The Poem
 966	James Dickey	James	Dickey	Q1377013	James Dickey	109230203	n79043450	male						judge	Columbia University	Pulitzer Prize	1981	poetry	book	15000.0	The Morning Of The Poem
 989	James Schuyler	James	Schuyler	Q5406329	James Schuyler	29553767	n79091463	male						winner	Columbia University	Pulitzer Prize	1981	poetry	book	15000.0	The Morning Of The Poem
 782	Garret Hongo	Garret	Hongo					male		graduate	Univeristy of California, Irvine			judge	Claremont Graduate University	Kate Tufts Discovery Award 	1995	poetry	book	10000.0	The Moon Reflected Fire
-1100	John (Jack) Miles	John (Jack)	Miles					male	Harvard University	graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	1995	poetry	book	10000.0	The Moon Reflected Fire
+1100	John (Jack) Miles	John (Jack)	Miles	Q45963	Jack Miles	24716819	n94067984	male	Harvard University	graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	1995	poetry	book	10000.0	The Moon Reflected Fire
 1680	Murray Schwartz	Murray	Schwartz					male		graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	1995	poetry	book	10000.0	The Moon Reflected Fire
 470	Daniel Halpern	Daniel	Halpern	Q55941553	Daniel Halpern	110940158	n50018478	male	Columbia University					judge	Claremont Graduate University	Kate Tufts Discovery Award 	1995	poetry	book	10000.0	The Moon Reflected Fire
-609	Doug Anderson	Doug	Anderson					male						winner	Claremont Graduate University	Kate Tufts Discovery Award 	1995	poetry	book	10000.0	The Moon Reflected Fire
+609	Doug Anderson	Doug	Anderson	Q15442047	Doug Anderson	84491764	no93016549	male						winner	Claremont Graduate University	Kate Tufts Discovery Award 	1995	poetry	book	10000.0	The Moon Reflected Fire
 803	George Garrett	George	Garrett	Q5539634	George Garrett	51736114	n50016965	male	Princeton University	graduate				judge	PEN America	Faulkner Award for Fiction	2006	prose	book	15000.0	The March
 617	E. L. Doctorow	E. L.	Doctorow	Q335232	E. L. Doctorow	14768905	n79021656	male						winner	PEN America	Faulkner Award for Fiction	2006	prose	book	15000.0	The March
 823	Glenway Wescott	Glenway	Wescott	Q347890	Glenway Wescott	12405830	n50003879	male						judge	National Book Foundation	National Book Award	1950	prose	book	10000.0	The Man With The Golden Arm
-2342	Wg Rogers	Wg	Rogers					male						judge	National Book Foundation	National Book Award	1950	prose	book	10000.0	The Man With The Golden Arm
+2342	Wg Rogers	Wg	Rogers	Q21607334	Julia Ellen Rogers	16265503	n86838453	male						judge	National Book Foundation	National Book Award	1950	prose	book	10000.0	The Man With The Golden Arm
 1479	Malcolm Cowley	Malcolm	Cowley	Q1458319	Malcolm Cowley	91308069	n79081720	male	Harvard University					judge	National Book Foundation	National Book Award	1950	prose	book	10000.0	The Man With The Golden Arm
 1600	Max Gissen	Max	Gissen	Q104814977	Max Gissen			male						judge	National Book Foundation	National Book Award	1950	prose	book	10000.0	The Man With The Golden Arm
 1715	Nelson Algren	Nelson	Algren	Q547914	Nelson Algren	44294455	n50033341	male						winner	National Book Foundation	National Book Award	1950	prose	book	10000.0	The Man With The Golden Arm
@@ -397,7 +397,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1982	Robert Pinsky	Robert	Pinsky	Q588807	Robert Pinsky	79069348	n83039273	male	Stanford University	graduate			Stegner	judge	Academy of American Poets	Lenore Marshall Poetry Prize	1993	poetry	book	25000.0	The Man With Night Sweats
 2215	Thom Gunn	Thom	Gunn	Q2141920	Thom Gunn	100054570	n79066390	male	Stanford University	graduate			Stegner	winner	Academy of American Poets	Lenore Marshall Poetry Prize	1993	poetry	book	25000.0	The Man With Night Sweats
 1598	Max Apple	Max	Apple	Q1912175	Max Apple	67778792	n81015616	male		graduate				judge	University of Pittsburg Press	Drue Heinz Literature Prize	1985	prose	book	15000.0	The Man Who Loved Levittown
-2327	Walter Wetherell	Walter	Wetherell					male						winner	University of Pittsburg Press	Drue Heinz Literature Prize	1985	prose	book	15000.0	The Man Who Loved Levittown
+2327	Walter Wetherell	Walter	Wetherell	Q7964645	Walter D. Wetherell	84250756	n81015086	male						winner	University of Pittsburg Press	Drue Heinz Literature Prize	1985	prose	book	15000.0	The Man Who Loved Levittown
 2344	Wilbur L. Cross	Wilbur L.	Cross					male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1925	poetry	book	15000.0	The Man Who Died Twice
 738	Ferris Greenslet	Ferris	Greenslet	Q5445372	Ferris Greenslet	52768436	n88640081	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1925	poetry	book	15000.0	The Man Who Died Twice
 643	Edwin Arlington Robinson	Edwin Arlington	Robinson	Q1294394	Edwin Arlington Robinson	64021896	n80008798	male	Harvard University					winner	Columbia University	Pulitzer Prize	1925	poetry	book	15000.0	The Man Who Died Twice
@@ -407,7 +407,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1755	Oscar Hijuelos	Oscar	Hijuelos	Q579475	Oscar Hijuelos	61601967	n82120993	male		graduate				winner	Columbia University	Pulitzer Prize	1990	prose	book	15000.0	The Mambo Kings Play Songs Of Love
 2374	William Pane	William	Pane					male						judge	Columbia University	Pulitzer Prize	1919	prose	book	15000.0	The Magnificent Ambersons
 2376	William Phelps	William	Phelps					male	Yale University, Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1919	prose	book	15000.0	The Magnificent Ambersons
-1961	Robert Grant	Robert	Grant	Q2157350	Robert Grant	261276674	n87896663	male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1919	prose	book	15000.0	The Magnificent Ambersons
+1961	Robert Grant	Robert	Grant	Q7344917	Robert Grant	28317113	n50032020	male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1919	prose	book	15000.0	The Magnificent Ambersons
 264	Booth Tarkington	Booth	Tarkington	Q893138	Booth Tarkington	54154708	n79078124	male	Princeton University					winner	Columbia University	Pulitzer Prize	1919	prose	book	15000.0	The Magnificent Ambersons
 452	Dagoberto Gilb	Dagoberto	Gilb	Q5208621	Dagoberto Gilb	67200425	n85243594	male		graduate				winner	PEN America	Hemingway Award for Debut Novel	1994	prose	book	10000.0	The Magic Of Blood
 863	Harry Hansen	Harry	Hansen	Q5669460	Harry Hansen	114815949	n50017751	male	University of Chicago	graduate				judge	National Book Foundation	National Book Award	1959	prose	book	10000.0	The Magic Barrel
@@ -427,7 +427,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1168	John Updike	John	Updike	Q105756	John Updike	90712179	n79018616	male	Harvard University					judge	National Book Foundation	National Book Award	1968	poetry	book	10000.0	The Light Around The Body
 270	Brando Skyhorse	Brando	Skyhorse	Q4956726	Brando Skyhorse			male	Stanford University	graduate	Univeristy of California, Irvine			judge	PEN America	Bellwether Prize for Socially Engaged Fiction	2016	prose	book	25000.0	The Leavers
 1037	Jefferson Fletcher	Jefferson	Fletcher					male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1938	prose	book	15000.0	The Late George Apley
-1213	Joseph Krutch	Joseph	Krutch					male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1938	prose	book	15000.0	The Late George Apley
+1213	Joseph Krutch	Joseph	Krutch	Q291183	Joseph Wood Krutch	49274843	n80007874	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1938	prose	book	15000.0	The Late George Apley
 1154	John Marquand	John	Marquand	Q1190579	John P. Marquand	7473159	n79061320	male	Harvard University					winner	Columbia University	Pulitzer Prize	1938	prose	book	15000.0	The Late George Apley
 1971	Robert Lovett	Robert	Lovett					male	Harvard University					judge	Columbia University	Pulitzer Prize	1938	prose	book	15000.0	The Late George Apley
 933	Ishmael Reed	Ishmael	Reed	Q983544	Ishmael Reed	29539664	n79078102	male						winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1975	prose	book	10000.0	The Last Days Of Louisiana Red
@@ -441,7 +441,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 48	Albert Duhamel	Albert	Duhamel					male		graduate				judge	Columbia University	Pulitzer Prize	1975	prose	book	15000.0	The Killer Angels
 1643	Michael Shaara	Michael	Shaara	Q739385	Michael Shaara	77624966	n80156369	male						winner	Columbia University	Pulitzer Prize	1975	prose	book	15000.0	The Killer Angels
 1604	Maxwell Geismar	Maxwell	Geismar	Q6796102	Maxwell Geismar	32932096	n50018262	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1965	prose	book	15000.0	The Keepers Of The House
-1390	Lewis Gannett	Lewis	Gannett	Q6536574	Lewis Gannett			male	Harvard University					judge	Columbia University	Pulitzer Prize	1965	prose	book	15000.0	The Keepers Of The House
+1390	Lewis Gannett	Lewis	Gannett	Q62224679	Lewis Gannett	11462821	n90622248	male	Harvard University					judge	Columbia University	Pulitzer Prize	1965	prose	book	15000.0	The Keepers Of The House
 2104	Shirley Ann Grau	Shirley Ann	Grau	Q459631	Shirley Ann Grau	108425435	n50032037	male						winner	Columbia University	Pulitzer Prize	1965	prose	book	15000.0	The Keepers Of The House
 1131	John Guare	John	Guare	Q320556	John Guare	71506879	n80065728	male		graduate	Yale University			judge	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2014	prose	book	10000.0	The Isle Of Youth
 1539	Mark Strand	Mark	Strand	Q928775	Mark Strand	49272680	n79090257	male	Yale University	graduate	University of Iowa	3152		judge	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2014	prose	book	10000.0	The Isle Of Youth
@@ -449,7 +449,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1423	Louis Begley	Louis	Begley	Q314843	Louis Begley	84023825	n91018358	male	Harvard University	graduate				judge	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2014	prose	book	10000.0	The Isle Of Youth
 513	David Gates	David	Gates	Q5234049	David Gates	7444659	n90719445	male						judge	University of Pittsburg Press	Drue Heinz Literature Prize	2017	prose	book	15000.0	The Islands
 2385	William Wall	William	Wall	Q8019919	William Wall	17131418	nr97033777	male						winner	University of Pittsburg Press	Drue Heinz Literature Prize	2017	prose	book	15000.0	The Islands
-986	James Robison	James	Robison	Q6142315	James Robison	284594587		male	Brown University	graduate	Brown University			winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1989	prose	book	10000.0	The Illustrator
+986	James Robison	James	Robison	Q6142315	James Robison	284594587	n84199490	male	Brown University	graduate	Brown University			winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1989	prose	book	10000.0	The Illustrator
 1535	Mark Richard	Mark	Richard	Q6769414	Mark Richard	102381015	n88073301	male						winner	PEN America	Hemingway Award for Debut Novel	1990	prose	book	10000.0	The Ice At The Bottom Of The World
 1843	Philip Roth	Philip	Roth	Q187019	Philip Roth	100235370	n79125808	male	University of Chicago	graduate				winner	PEN America	Faulkner Award for Fiction	2001	prose	book	15000.0	The Human Stain
 973	James Houston	James	Houston	Q6128810	James Archibald Houston	90715596	n79108351	male	Stanford University	graduate				judge	PEN America	Faulkner Award for Fiction	2001	prose	book	15000.0	The Human Stain
@@ -472,7 +472,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1026	Jay Parini	Jay	Parini	Q1329542	Jay Parini	108228615	n79047333	male		graduate				judge	National Book Foundation	National Book Award	2003	prose	book	10000.0	The Great Fire
 1818	Peter Cameron	Peter	Cameron	Q3376491	Peter Cameron	12330519	n85186638	male						judge	National Book Foundation	National Book Award	2003	prose	book	10000.0	The Great Fire
 1037	Jefferson Fletcher	Jefferson	Fletcher					male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1940	prose	book	15000.0	The Grapes Of Wrath
-1213	Joseph Krutch	Joseph	Krutch					male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1940	prose	book	15000.0	The Grapes Of Wrath
+1213	Joseph Krutch	Joseph	Krutch	Q291183	Joseph Wood Krutch	49274843	n80007874	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1940	prose	book	15000.0	The Grapes Of Wrath
 1167	John Steinbeck	John	Steinbeck	Q39212	John Steinbeck	48715287	nb91056582	male	Stanford University					winner	Columbia University	Pulitzer Prize	1940	prose	book	15000.0	The Grapes Of Wrath
 1971	Robert Lovett	Robert	Lovett					male	Harvard University					judge	Columbia University	Pulitzer Prize	1940	prose	book	15000.0	The Grapes Of Wrath
 2199	Ted Genoways	Ted	Genoways	Q15451922	Ted Genoways	251903	n94105509	male		graduate	University of Virginia			judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2014	poetry	book	100000.0	The Government Of Nature
@@ -496,7 +496,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1795	Paul Steiger	Paul	Steiger	Q16106106	Paul Steiger			male	Princeton University					judge	PEN America	Diamonstein-Spielvogel Award For The Art Of The Essay	2017	prose	book	15000.0	The Girls In My Town: Essays
 379	Chris Bachelder	Chris	Bachelder	Q5105779	Chris Bachelder	18210819	n2001031422	male		graduate	University of Florida			judge	National Book Foundation	National Book Award	2018	prose	book	10000.0	The Friend
 869	Hayden Carruth	Hayden	Carruth	Q4357709	Hayden Carruth	79047287	n50032361	male	University of Chicago	graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	1976	poetry	book	25000.0	The Freeing Of The Dust
-2371	William Matthews	William	Matthews					male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1986	poetry	book	15000.0	The Flying Change: Poems
+2371	William Matthews	William	Matthews	Q8015241	William Matthews	56838912	n78092891	male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1986	poetry	book	15000.0	The Flying Change: Poems
 1429	Louis Simpson	Louis	Simpson	Q1871997	Louis Simpson	7509913	n50023694	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1986	poetry	book	15000.0	The Flying Change: Poems
 884	Henry Taylor	Henry	Taylor	Q1607302	Henry Taylor	64022130	n85157620	male		graduate				winner	Columbia University	Pulitzer Prize	1986	poetry	book	15000.0	The Flying Change: Poems
 2344	Wilbur L. Cross	Wilbur L.	Cross					male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1932	poetry	book	15000.0	The Flowering Stone
@@ -537,11 +537,11 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1430	Louis Untermeyer	Louis	Untermeyer	Q1872015	Louis Untermeyer	39541598	n79054344	male						judge	Columbia University	Pulitzer Prize	1942	poetry	book	15000.0	The Dust Which Is God
 751	Frank Bidart	Frank	Bidart	Q5485312	Frank Bidart	90719088	n83022171	male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1996	poetry	book	15000.0	The Dream of the Unified Field
 1170	John Wheatcroft	John	Wheatcroft	Q6263703	John Wheatcroft	20909994	n80005688	male						judge	Columbia University	Pulitzer Prize	1996	poetry	book	15000.0	The Dream of the Unified Field
-2354	William Alfred	William	Alfred					male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1974	poetry	book	15000.0	The Dolphin
+2354	William Alfred	William	Alfred	Q8004294	William Alfred	53072398	n83208234	male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1974	poetry	book	15000.0	The Dolphin
 173	Anthony Hecht	Anthony	Hecht	Q3618497	Anthony Hecht	76363549	n79148935	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1974	poetry	book	15000.0	The Dolphin
 1972	Robert Lowell	Robert	Lowell	Q981448	Robert Lowell	17249803	n79023350	male		graduate				winner	Columbia University	Pulitzer Prize	1974	poetry	book	15000.0	The Dolphin
-265	Brad Felver	Brad	Felver					male	Harvard University	graduate	Bowling Green State University			winner	University of Pittsburg Press	Drue Heinz Literature Prize	2018	prose	book	15000.0	The Dogs Of Detroit
-948	Jack Livings	Jack	Livings	Q20723465	Jack Livingston	57949058	n81151251	male		graduate	University of Iowa	2463		winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2015	prose	book	25000.0	The Dog
+265	Brad Felver	Brad	Felver			27153713824458661752	no2018121845	male	Harvard University	graduate	Bowling Green State University			winner	University of Pittsburg Press	Drue Heinz Literature Prize	2018	prose	book	15000.0	The Dogs Of Detroit
+948	Jack Livings	Jack	Livings	Q107484189	Jack Livings			male		graduate	University of Iowa	2463		winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2015	prose	book	25000.0	The Dog
 2302	Victor Lavalle	Victor	Lavalle	Q7926078	Victor LaValle	165884191	n99023474	male	Cornell University, Columbia University	graduate	Columbia University			judge	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2015	prose	book	25000.0	The Dog
 1791	Paul Lafarge	Paul	Lafarge	Q7151893	Paul LaFarge	60865321	n98098676	male	Yale University					judge	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2015	prose	book	25000.0	The Dog
 45	Alan Shapiro	Alan	Shapiro	Q4707746	Alan Shapiro	32211496	n83068994	male	Stanford University	graduate			Stegner	judge	Academy of American Poets	Lenore Marshall Poetry Prize	2005	poetry	book	25000.0	The Displaced Of Capital
@@ -556,32 +556,32 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 208	B. H. Fairchild	B. H.	Fairchild	Q4834012	B. H. Fairchild	75149721	n80062669	male		graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2001	poetry	book	100000.0	The Dead Alive And Busy
 361	Charles Rowell	Charles	Rowell					male		graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2001	poetry	book	100000.0	The Dead Alive And Busy
 510	David Ebershoff	David	Ebershoff	Q5233250	David Ebershoff	29707432	n99041185	male	Brown University, University of Chicago	graduate	University of Chicago			winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2001	prose	book	10000.0	The Danish Girl
-776	Gabriel Brownstein	Gabriel	Brownstein					male	Columbia University	graduate	Columbia University			winner	PEN America	Hemingway Award for Debut Novel	2003	prose	book	10000.0	The Curious Case Of Benjamin Button, Apt. 3W
+776	Gabriel Brownstein	Gabriel	Brownstein			12533473	n2002029880	male	Columbia University	graduate	Columbia University			winner	PEN America	Hemingway Award for Debut Novel	2003	prose	book	10000.0	The Curious Case Of Benjamin Button, Apt. 3W
 1076	Jim Shepard	Jim	Shepard	Q6198081	Jim Shepard	39613753	n83121472	male	Brown University	graduate	Brown University			judge	PEN America	Hemingway Award for Debut Novel	2003	prose	book	10000.0	The Curious Case Of Benjamin Button, Apt. 3W
 1812	Percival Everett	Percival	Everett	Q3375158	Percival Everett	120212810	n83043473	male	Brown University	graduate	Brown University			judge	PEN America	Hemingway Award for Debut Novel	2003	prose	book	10000.0	The Curious Case Of Benjamin Button, Apt. 3W
-537	David Morris	David	Morris					male		graduate				winner	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	1992	prose	book	15000.0	The Culture Of Pain
+537	David Morris	David	Morris	Q16732886	David Morris	108664430	n83188015	male		graduate				winner	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	1992	prose	book	15000.0	The Culture Of Pain
 2230	Thomas Pynchon	Thomas	Pynchon	Q35155	Thomas Pynchon	88986700	n79099184	male	Cornell University					winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1967	prose	book	10000.0	The Crying Of Lot 49
 771	Frederick Crews	Frederick	Crews	Q3087101	Frederick Crews	9895057	n79127921	male	Yale University, Princeton University	graduate				winner	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	1993	prose	book	15000.0	The Critics Bear It Away: American Fiction And The Academy 
 1916	Richard Steve	Richard	Steve					male						judge	National Book Foundation	National Book Award	2001	prose	book	10000.0	The Corrections
 421	Colin Harrison	Colin	Harrison	Q1108495	Colin Harrison	39476338	n88177727	male		graduate	University of Iowa	1675		judge	National Book Foundation	National Book Award	2001	prose	book	10000.0	The Corrections
-250	Bill Henderson	Bill	Henderson	Q4909398	Bill Henderson	92516934	n84002338	male						judge	National Book Foundation	National Book Award	2001	prose	book	10000.0	The Corrections
+250	Bill Henderson	Bill	Henderson					male						judge	National Book Foundation	National Book Award	2001	prose	book	10000.0	The Corrections
 1185	Jonathan Franzen	Jonathan	Franzen	Q316607	Jonathan Franzen	84489381	n88015344	male						winner	National Book Foundation	National Book Award	2001	prose	book	10000.0	The Corrections
 1604	Maxwell Geismar	Maxwell	Geismar	Q6796102	Maxwell Geismar	32932096	n50018262	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1968	prose	book	15000.0	The Confessions Of Nat Turner
 1620	Melvin Maddocks	Melvin	Maddocks					male	Harvard University					judge	Columbia University	Pulitzer Prize	1968	prose	book	15000.0	The Confessions Of Nat Turner
 1141	John Hutch	John	Hutch					male						judge	Columbia University	Pulitzer Prize	1968	prose	book	15000.0	The Confessions Of Nat Turner
 2382	William Styron	William	Styron	Q245257	William Styron	71398096	n79022959	male						winner	Columbia University	Pulitzer Prize	1968	prose	book	15000.0	The Confessions Of Nat Turner
-2231	Thomas Rogers	Thomas	Rogers					male	Harvard University	graduate				winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1973	prose	book	10000.0	The Confession Of A Child Of The Century
+2231	Thomas Rogers	Thomas	Rogers	Q2426878	Thomas Rogers	61668891	n80086170	male	Harvard University	graduate				winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1973	prose	book	10000.0	The Confession Of A Child Of The Century
 398	Christopher Lehman-Haupt	Christopher	Lehman-Haupt					male		graduate	Yale University			judge	National Book Foundation	National Book Award	1972	prose	book	10000.0	The Complete Stories
 493	Daryl Hine	Daryl	Hine	Q5226186	Daryl Hine	94517620	n50034948	male	University of Chicago	graduate				judge	National Book Foundation	National Book Award	1972	prose	book	10000.0	The Complete Stories
 1210	Joseph Heller	Joseph	Heller	Q208101	Joseph Heller	36926967	n79100545	male	Columbia University	graduate				judge	National Book Foundation	National Book Award	1972	prose	book	10000.0	The Complete Stories
 1348	Larry Woiwode	Larry	Woiwode	Q6491303	Larry Woiwode	37482664	n81085667	male						judge	National Book Foundation	National Book Award	1972	prose	book	10000.0	The Complete Stories
 2373	William Meredith	William	Meredith					male	Princeton University					judge	National Book Foundation	National Book Award	1970	poetry	book	10000.0	The Complete Poems
 1310	Kenneth Rexroth	Kenneth	Rexroth	Q516447	Kenneth Rexroth	105850695	n79055282	male						judge	National Book Foundation	National Book Award	1970	poetry	book	10000.0	The Complete Poems
-1828	Peter Prescott	Peter	Prescott					male	Harvard University					judge	Columbia University	Pulitzer Prize	1983	prose	book	15000.0	The Color Purple
-1139	John Holmes	John	Holmes					male						judge	Columbia University	Pulitzer Prize	1983	prose	book	15000.0	The Color Purple
+1828	Peter Prescott	Peter	Prescott	Q15544954	Peter S. Prescott	22448479	n50028228	male	Harvard University					judge	Columbia University	Pulitzer Prize	1983	prose	book	15000.0	The Color Purple
+1139	John Holmes	John	Holmes	Q6239670	John Holmes	85144928712954440017	n85274137	male						judge	Columbia University	Pulitzer Prize	1983	prose	book	15000.0	The Color Purple
 2353	Willard Thorp	Willard	Thorp	Q56884997	Willard William Thorp	110033000	n80026717	male	Princeton University, Harvard University	graduate				judge	National Book Foundation	National Book Award	1951	prose	book	10000.0	The Collected Stories Of William Faulkner
 832	Granville Hicks	Granville	Hicks	Q5596907	Granville Hicks	45106022	n50035079	male	Harvard University	graduate				judge	National Book Foundation	National Book Award	1951	prose	book	10000.0	The Collected Stories Of William Faulkner
-359	Charles Rolo	Charles	Rolo					male	Columbia University	graduate				judge	National Book Foundation	National Book Award	1951	prose	book	10000.0	The Collected Stories Of William Faulkner
+359	Charles Rolo	Charles	Rolo	Q59630104	Charles James Rolo	69964446	n82020036	male	Columbia University	graduate				judge	National Book Foundation	National Book Award	1951	prose	book	10000.0	The Collected Stories Of William Faulkner
 1604	Maxwell Geismar	Maxwell	Geismar	Q6796102	Maxwell Geismar	32932096	n50018262	male	Columbia University	graduate				judge	National Book Foundation	National Book Award	1951	prose	book	10000.0	The Collected Stories Of William Faulkner
 2361	William Faulkner	William	Faulkner	Q38392	William Faulkner	39376770	n79003304	male						winner	National Book Foundation	National Book Award	1951	prose	book	10000.0	The Collected Stories Of William Faulkner
 823	Glenway Wescott	Glenway	Wescott	Q347890	Glenway Wescott	12405830	n50003879	male						judge	National Book Foundation	National Book Award	1966	prose	book	10000.0	The Collected Stories Of Katherine Anne Porter
@@ -619,19 +619,19 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2396	W. S. Merwin	W. S.	Merwin	Q680368	W. S. Merwin	110923132	n50036920	male	Princeton University					winner	Columbia University	Pulitzer Prize	1971	poetry	book	15000.0	The Carrier Of Ladders
 66	Alexs Pate	Alexs	Pate	Q16734244	Alexs Pate	44442865	n93104225	male						judge	PEN America	Faulkner Award for Fiction	2003	prose	book	15000.0	The Caprices
 2023	Roy Couden	Roy	Couden					male						judge	Columbia University	Pulitzer Prize	1952	prose	book	15000.0	The Caine Mutiny
-704	Eric Kelly	Eric	Kelly					male	Dartmouth College					judge	Columbia University	Pulitzer Prize	1952	prose	book	15000.0	The Caine Mutiny
+704	Eric Kelly	Eric	Kelly	Q5387228	Eric P. Kelly	79366435	n50048142	male	Dartmouth College					judge	Columbia University	Pulitzer Prize	1952	prose	book	15000.0	The Caine Mutiny
 892	Herman Wouk	Herman	Wouk	Q49072	Herman Wouk	17231124	n79032317	male	Columbia University					winner	Columbia University	Pulitzer Prize	1952	prose	book	15000.0	The Caine Mutiny
 2153	Steve Yarbrough	Steve	Yarbrough	Q7614372	Steve Yarbrough	59149477	n90611067	male		graduate	University of Arkansas			judge	PEN America	Faulkner Award for Fiction	2012	prose	book	15000.0	The Buddha In The Attic
 1248	Junot Diaz	Junot	Diaz	Q402664	Junot Díaz	79142980	n96034971	male	Cornell University	graduate	Cornell University			winner	Center for Fiction	First Novel Prize	2007	prose	book	15000.0	The Brief Wondrous Life Of Oscar Wao
 1248	Junot Diaz	Junot	Diaz	Q402664	Junot Díaz	79142980	n96034971	male	Cornell University	graduate	Cornell University			winner	Columbia University	Pulitzer Prize	2008	prose	book	15000.0	The Brief Wondrous Life Of Oscar Wao
 522	David Kennedy	David	Kennedy	Q1975383	David A. Kennedy	104825600		male	Stanford University, Yale University	graduate				judge	Columbia University	Pulitzer Prize	2008	prose	book	15000.0	The Brief Wondrous Life Of Oscar Wao
-1165	John Searles	John	Searles	Q6257188	John Searles	32174588		male		graduate				judge	Center for Fiction	First Novel Prize	2007	prose	book	15000.0	The Brief Wondrous Life Of Oscar Wao
+1165	John Searles	John	Searles	Q6257188	John Searles	32174588	n00031188	male		graduate				judge	Center for Fiction	First Novel Prize	2007	prose	book	15000.0	The Brief Wondrous Life Of Oscar Wao
 1756	Oscar Villalon	Oscar	Villalon					male						judge	Columbia University	Pulitzer Prize	2008	prose	book	15000.0	The Brief Wondrous Life Of Oscar Wao
 2238	Thornton Wilder	Thornton	Wilder	Q155087	Thornton Wilder	100167035	n79062874	male	Yale University, Princeton University	graduate				winner	Columbia University	Pulitzer Prize	1928	prose	book	15000.0	The Bridge Of San Luis Rey
 1037	Jefferson Fletcher	Jefferson	Fletcher					male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1928	prose	book	15000.0	The Bridge Of San Luis Rey
-1897	Richard Burton	Richard	Burton	Q125057	Richard Francis Burton	29832058	n80057204	male		graduate				judge	Columbia University	Pulitzer Prize	1928	prose	book	15000.0	The Bridge Of San Luis Rey
+1897	Richard Burton	Richard	Burton	Q84554359	Richard Burton	16015250	n50033772	male		graduate				judge	Columbia University	Pulitzer Prize	1928	prose	book	15000.0	The Bridge Of San Luis Rey
 1971	Robert Lovett	Robert	Lovett					male	Harvard University					judge	Columbia University	Pulitzer Prize	1928	prose	book	15000.0	The Bridge Of San Luis Rey
-1151	John Logan	John	Logan	Q384004	John Logan	104842082	n96057236	male		graduate				winner	Academy of American Poets	Lenore Marshall Poetry Prize	1982	poetry	book	25000.0	The Bridge Of Change: Poems 1974-1980
+1151	John Logan	John	Logan	Q6245151	John Logan	85933786	n50039516	male		graduate				winner	Academy of American Poets	Lenore Marshall Poetry Prize	1982	poetry	book	25000.0	The Bridge Of Change: Poems 1974-1980
 2366	William Jay Smith	William Jay	Smith	Q4355736	William Jay Smith	1176890	n79042253	male		graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	1982	poetry	book	25000.0	The Bridge Of Change: Poems 1974-1980
 1802	Paul Zweig	Paul	Zweig	Q6563032	Paul Zweig	109387851	n50015936	male	Columbia University					judge	Academy of American Poets	Lenore Marshall Poetry Prize	1982	poetry	book	25000.0	The Bridge Of Change: Poems 1974-1980
 1988	Robert Wrigley	Robert	Wrigley	Q7351272	Robert Wrigley	52952040	n78090918	male		graduate	University of Montana			judge	Claremont Graduate University	Kate Tufts Discovery Award 	2004	poetry	book	10000.0	The Brass Girl Brouhaha
@@ -647,7 +647,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 540	David Quammen	David	Quammen	Q1176215	David Quammen	37032561	n80139796	male	Yale University	graduate				winner	PEN America	Diamonstein-Spielvogel Award For The Art Of The Essay	2001	prose	book	15000.0	The Boilerplate Rhino: Nature in the Eye of the Beholder
 782	Garret Hongo	Garret	Hongo					male		graduate	Univeristy of California, Irvine			judge	Claremont Graduate University	Kate Tufts Discovery Award 	1997	poetry	book	10000.0	The Body Mutinies
 787	Gary Soto	Gary	Soto	Q5525966	Gary Soto	24617649	n80082328	male		graduate	Univeristy of California, Irvine			judge	Claremont Graduate University	Kate Tufts Discovery Award 	1997	poetry	book	10000.0	The Body Mutinies
-1100	John (Jack) Miles	John (Jack)	Miles					male	Harvard University	graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	1997	poetry	book	10000.0	The Body Mutinies
+1100	John (Jack) Miles	John (Jack)	Miles	Q45963	Jack Miles	24716819	n94067984	male	Harvard University	graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	1997	poetry	book	10000.0	The Body Mutinies
 470	Daniel Halpern	Daniel	Halpern	Q55941553	Daniel Halpern	110940158	n50018478	male	Columbia University					judge	Claremont Graduate University	Kate Tufts Discovery Award 	1997	poetry	book	10000.0	The Body Mutinies
 2200	Ted Kooser	Ted	Kooser	Q140196	Ted Kooser	238235132	n78078777	male		graduate				judge	Columbia University	Pulitzer Prize	2011	poetry	book	15000.0	The Best Of It: New And Selected Poems
 1471	Madison Smart Bell	Madison Smart	Bell					male	Princeton University	graduate				judge	PEN America	Faulkner Award for Fiction	1998	prose	book	15000.0	The Bear Comes Home
@@ -672,7 +672,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 235	Bernard Malamud	Bernard	Malamud	Q351547	Bernard Malamud	34459928	n79046272	male	Columbia University	graduate				winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1958	prose	book	10000.0	The Assistant
 782	Garret Hongo	Garret	Hongo					male		graduate	Univeristy of California, Irvine			judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1999	poetry	book	100000.0	The Art Of The Lathe
 787	Gary Soto	Gary	Soto	Q5525966	Gary Soto	24617649	n80082328	male		graduate	Univeristy of California, Irvine			judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1999	poetry	book	100000.0	The Art Of The Lathe
-1100	John (Jack) Miles	John (Jack)	Miles					male	Harvard University	graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1999	poetry	book	100000.0	The Art Of The Lathe
+1100	John (Jack) Miles	John (Jack)	Miles	Q45963	Jack Miles	24716819	n94067984	male	Harvard University	graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1999	poetry	book	100000.0	The Art Of The Lathe
 208	B. H. Fairchild	B. H.	Fairchild	Q4834012	B. H. Fairchild	75149721	n80062669	male		graduate				winner	Claremont Graduate University	Kingsley Tufts Poetry Award	1999	poetry	book	100000.0	The Art Of The Lathe
 470	Daniel Halpern	Daniel	Halpern	Q55941553	Daniel Halpern	110940158	n50018478	male	Columbia University					judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1999	poetry	book	100000.0	The Art Of The Lathe
 460	Dana Gioia	Dana	Gioia	Q5214728	Dana Gioia	93074201	n83016621	male	Stanford University, Harvard University	graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	1983	poetry	book	25000.0	The Argot Merchant Disaster
@@ -694,7 +694,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1374	Leon Edel	Leon	Edel	Q611518	Leon Edel	108589496	n79018725	male						judge	National Book Foundation	National Book Award	1954	prose	book	10000.0	The Adventures Of Augie March
 1037	Jefferson Fletcher	Jefferson	Fletcher					male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1924	prose	book	15000.0	The Able McLaughlins
 256	Bliss Perry	Bliss	Perry	Q4926866	Bliss Perry	76448095	n50009730	male		graduate				judge	Columbia University	Pulitzer Prize	1924	prose	book	15000.0	The Able McLaughlins
-2049	Samuel Crothers	Samuel	Crothers					male						judge	Columbia University	Pulitzer Prize	1924	prose	book	15000.0	The Able McLaughlins
+2049	Samuel Crothers	Samuel	Crothers	Q7412138	Samuel McChord Crothers	66604792	n50057777	male						judge	Columbia University	Pulitzer Prize	1924	prose	book	15000.0	The Able McLaughlins
 2363	William Gass	William	Gass	Q304874	William H. Gass	108798167	n79096948	male	Cornell University	graduate				winner	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	2003	prose	book	15000.0	Test Of Time: Essays
 70	Alfred Kreynborg	Alfred	Kreynborg					male						judge	Columbia University	Pulitzer Prize	1949	poetry	book	15000.0	Terror And Decorum
 883	Henry Seidel Canby	Henry Seidel	Canby	Q15501218	Henry Seidel Canby	7559111	n50051945	male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1949	poetry	book	15000.0	Terror And Decorum
@@ -703,25 +703,25 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 832	Granville Hicks	Granville	Hicks	Q5596907	Granville Hicks	45106022	n50035079	male	Harvard University	graduate				judge	National Book Foundation	National Book Award	1956	prose	book	10000.0	Ten North Frederick
 1537	Mark Schorer	Mark	Schorer	Q6769632	Mark Schorer	6174258	n50002798	male	Harvard University	graduate				judge	National Book Foundation	National Book Award	1956	prose	book	10000.0	Ten North Frederick
 314	Carlos Baker	Carlos	Baker	Q5041809	Carlos Baker	107027003	n50020883	male	Dartmouth College, Harvard University, Princeton University	graduate				judge	National Book Foundation	National Book Award	1956	prose	book	10000.0	Ten North Frederick
-2074	Saunders Redding	Saunders	Redding					male	Brown University	graduate				judge	National Book Foundation	National Book Award	1956	prose	book	10000.0	Ten North Frederick
+2074	Saunders Redding	Saunders	Redding	Q41799670	J. Saunders Redding	109812216	n50046089	male	Brown University	graduate				judge	National Book Foundation	National Book Award	1956	prose	book	10000.0	Ten North Frederick
 1972	Robert Lowell	Robert	Lowell	Q981448	Robert Lowell	17249803	n79023350	male		graduate				judge	National Book Foundation	National Book Award	1956	prose	book	10000.0	Ten North Frederick
-1113	John Brooks	John	Brooks					male	Princeton University					judge	National Book Foundation	National Book Award	1956	prose	book	10000.0	Ten North Frederick
+1113	John Brooks	John	Brooks	Q6223379	John Brooks	62709532	n79063009	male	Princeton University					judge	National Book Foundation	National Book Award	1956	prose	book	10000.0	Ten North Frederick
 1162	John O'Hara	John	O'Hara	Q548345	John O'Hara	12429524	n79060653	male						winner	National Book Foundation	National Book Award	1956	prose	book	10000.0	Ten North Frederick
 2199	Ted Genoways	Ted	Genoways	Q15451922	Ted Genoways	251903	n94105509	male		graduate	University of Virginia			judge	Claremont Graduate University	Kate Tufts Discovery Award 	2010	poetry	book	10000.0	Temper
 501	David Barber	David	Barber					male	Stanford University	graduate			Stegner	judge	Claremont Graduate University	Kate Tufts Discovery Award 	2010	poetry	book	10000.0	Temper
 310	Carl Phillips	Carl	Phillips	Q5040647	Carl Phillips	71523238	n92066382	male	Harvard University	graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	2010	poetry	book	10000.0	Temper
 1604	Maxwell Geismar	Maxwell	Geismar	Q6796102	Maxwell Geismar	32932096	n50018262	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1948	prose	book	15000.0	Tales Of The Pacific
 983	James Michener	James	Michener	Q361653	James A. Michener	34460537	n79058583	male		graduate				winner	Columbia University	Pulitzer Prize	1948	prose	book	15000.0	Tales Of The Pacific
-1115	John Chamberlain	John	Chamberlain	Q6225650	John Chamberlain	39748463	nr90005975	male	Yale University					judge	Columbia University	Pulitzer Prize	1948	prose	book	15000.0	Tales Of The Pacific
+1115	John Chamberlain	John	Chamberlain	Q6225652	John Chamberlain	3841537	n83021282	male	Yale University					judge	Columbia University	Pulitzer Prize	1948	prose	book	15000.0	Tales Of The Pacific
 1752	Orville Prescott	Orville	Prescott	Q7105248	Orville Prescott	237553275	n50028227	male						judge	Columbia University	Pulitzer Prize	1948	prose	book	15000.0	Tales Of The Pacific
 2344	Wilbur L. Cross	Wilbur L.	Cross					male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1941	poetry	book	15000.0	Sunderland Capture
 1037	Jefferson Fletcher	Jefferson	Fletcher					male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1941	prose	book	15000.0	Sunderland Capture
-1213	Joseph Krutch	Joseph	Krutch					male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1941	prose	book	15000.0	Sunderland Capture
+1213	Joseph Krutch	Joseph	Krutch	Q291183	Joseph Wood Krutch	49274843	n80007874	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1941	prose	book	15000.0	Sunderland Capture
 256	Bliss Perry	Bliss	Perry	Q4926866	Bliss Perry	76448095	n50009730	male		graduate				judge	Columbia University	Pulitzer Prize	1941	poetry	book	15000.0	Sunderland Capture
 1375	Leonard Bacon	Leonard	Bacon	Q6525095	Leonard Bacon	39750079	no96044132	male	Yale University					winner	Columbia University	Pulitzer Prize	1941	poetry	book	15000.0	Sunderland Capture
 2380	William Rose Benét	William Rose	Benét	Q2580418	William Rose Benét	45096102	n50008106	male	Yale University					judge	Columbia University	Pulitzer Prize	1941	poetry	book	15000.0	Sunderland Capture
 2344	Wilbur L. Cross	Wilbur L.	Cross					male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1936	poetry	book	15000.0	Strange Holiness
-1948	Robert Coffin	Robert	Coffin					male	Princeton University	graduate				winner	Columbia University	Pulitzer Prize	1936	poetry	book	15000.0	Strange Holiness
+1948	Robert Coffin	Robert	Coffin	Q1508766	Robert P. T. Coffin	74743157	n50030030	male	Princeton University	graduate				winner	Columbia University	Pulitzer Prize	1936	poetry	book	15000.0	Strange Holiness
 256	Bliss Perry	Bliss	Perry	Q4926866	Bliss Perry	76448095	n50009730	male		graduate				judge	Columbia University	Pulitzer Prize	1936	poetry	book	15000.0	Strange Holiness
 1375	Leonard Bacon	Leonard	Bacon	Q6525095	Leonard Bacon	39750079	no96044132	male	Yale University					judge	Columbia University	Pulitzer Prize	1936	poetry	book	15000.0	Strange Holiness
 1789	Paul Harding	Paul	Harding	Q692219	Paul Harding	163938405	n2008062825	male		graduate	University of Iowa	2455		judge	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2011	prose	book	25000.0	Stiltsville
@@ -736,10 +736,10 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 782	Garret Hongo	Garret	Hongo					male		graduate	Univeristy of California, Irvine			judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1997	poetry	book	100000.0	Spring Comes To Chicago
 787	Gary Soto	Gary	Soto	Q5525966	Gary Soto	24617649	n80082328	male		graduate	Univeristy of California, Irvine			judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1997	poetry	book	100000.0	Spring Comes To Chicago
 308	Campbell McGrath	Campbell	McGrath	Q5028114	Campbell McGrath	75419034	n88246386	male	University of Chicago, Columbia University	graduate	Columbia University			winner	Claremont Graduate University	Kingsley Tufts Poetry Award	1997	poetry	book	100000.0	Spring Comes To Chicago
-1100	John (Jack) Miles	John (Jack)	Miles					male	Harvard University	graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1997	poetry	book	100000.0	Spring Comes To Chicago
+1100	John (Jack) Miles	John (Jack)	Miles	Q45963	Jack Miles	24716819	n94067984	male	Harvard University	graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1997	poetry	book	100000.0	Spring Comes To Chicago
 470	Daniel Halpern	Daniel	Halpern	Q55941553	Daniel Halpern	110940158	n50018478	male	Columbia University					judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1997	poetry	book	100000.0	Spring Comes To Chicago
 782	Garret Hongo	Garret	Hongo					male		graduate	Univeristy of California, Irvine			judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1995	poetry	book	100000.0	Split Horizon
-1100	John (Jack) Miles	John (Jack)	Miles					male	Harvard University	graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1995	poetry	book	100000.0	Split Horizon
+1100	John (Jack) Miles	John (Jack)	Miles	Q45963	Jack Miles	24716819	n94067984	male	Harvard University	graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1995	poetry	book	100000.0	Split Horizon
 1680	Murray Schwartz	Murray	Schwartz					male		graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1995	poetry	book	100000.0	Split Horizon
 470	Daniel Halpern	Daniel	Halpern	Q55941553	Daniel Halpern	110940158	n50018478	male	Columbia University					judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1995	poetry	book	100000.0	Split Horizon
 2222	Thomas Lux	Thomas	Lux	Q7791985	Thomas Lux	4959112	n79063797	male						winner	Claremont Graduate University	Kingsley Tufts Poetry Award	1995	poetry	book	100000.0	Split Horizon
@@ -750,7 +750,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2118	Spencer Holst	Spencer	Holst	Q7576080	Spencer Holst	237135671	n86870596	male						winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1977	prose	book	10000.0	Spencer Holst Stories
 1928	Rick Moody	Rick	Moody	Q709368	Rick Moody	2604389	nr92020208	male	Brown University, Columbia University	graduate	Columbia University			judge	University of Pittsburg Press	Drue Heinz Literature Prize	2003	prose	book	15000.0	Speed-Walk And Other Stories
 189	Arnold Dolin	Arnold	Dolin					male		graduate				judge	Center for Fiction	First Novel Prize	2006	prose	book	15000.0	Special Topics In Calamity Physics
-1165	John Searles	John	Searles	Q6257188	John Searles	32174588		male		graduate				judge	Center for Fiction	First Novel Prize	2006	prose	book	15000.0	Special Topics In Calamity Physics
+1165	John Searles	John	Searles	Q6257188	John Searles	32174588	n00031188	male		graduate				judge	Center for Fiction	First Novel Prize	2006	prose	book	15000.0	Special Topics In Calamity Physics
 1114	John Casey	John	Casey	Q6225438	John Casey	32033282	n84161567	male	Harvard University	graduate	University of Iowa	366		winner	National Book Foundation	National Book Award	1989	prose	book	10000.0	Spartina
 227	Benjamin Demott	Benjamin	Demott	Q817443	Benjamin DeMott	34977068	n88041876	male	Harvard University	graduate				judge	National Book Foundation	National Book Award	1989	prose	book	10000.0	Spartina
 2220	Thomas Flanagan	Thomas	Flanagan	Q2416071	Thomas Flanagan	79025241	n86115835	male	Columbia University	graduate				judge	National Book Foundation	National Book Award	1989	prose	book	10000.0	Spartina
@@ -767,7 +767,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 35	Al Young	Al	Young	Q4705004	Al Young	61622497	n80007959	male	Stanford University	graduate			Stegner	judge	PEN America	Faulkner Award for Fiction	1987	prose	book	15000.0	Soldiers In Hiding
 2372	William Maxwell	William	Maxwell	Q1541271	William Keepers Maxwell, Jr.	114674264	n79065705	male	Harvard University	graduate				winner	National Book Foundation	National Book Award	1982	prose	book	10000.0	So Long, See You Tomorrow
 1037	Jefferson Fletcher	Jefferson	Fletcher					male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1925	prose	book	15000.0	So Big
-1754	Oscar Firkins	Oscar	Firkins					male		graduate				judge	Columbia University	Pulitzer Prize	1925	prose	book	15000.0	So Big
+1754	Oscar Firkins	Oscar	Firkins	Q18561020	Oscar W. Firkins	38058635	n50005306	male		graduate				judge	Columbia University	Pulitzer Prize	1925	prose	book	15000.0	So Big
 2387	William White	William	White					male						judge	Columbia University	Pulitzer Prize	1925	prose	book	15000.0	So Big
 515	David Guterson	David	Guterson	Q1174627	David Guterson	84055110	n88159394	male		graduate	University of Washington			winner	PEN America	Faulkner Award for Fiction	1995	prose	book	15000.0	Snow Falling On Cedars
 2368	William Kittredge	William	Kittredge	Q3568766	William Kittredge	93349615	n77016661	male	Stanford University	graduate	University of Iowa	459	Stegner	judge	PEN America	Faulkner Award for Fiction	1995	prose	book	15000.0	Snow Falling On Cedars
@@ -780,7 +780,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 196	Arthur Sze	Arthur	Sze	Q4800412	Arthur Sze	1346498	n82011115	male						winner	National Book Foundation	National Book Award	2019	poetry	book	10000.0	Sight Lines
 431	Cornelius Eady	Cornelius	Eady	Q5171355	Cornelius Eady	77765819	n85266803	male		graduate	Warren Wilson College			judge	Academy of American Poets	Lenore Marshall Poetry Prize	2013	poetry	book	25000.0	Shoulda Been Jimi Savannah
 835	Gregory Orr	Gregory	Orr	Q5607095	Gregory Orr	29550833	n80050958	male	Columbia University	graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	2013	poetry	book	25000.0	Shoulda Been Jimi Savannah
-504	David Bradley	David	Bradley					male	University of Pennsylvania	graduate				judge	National Book Foundation	National Book Award	1996	prose	book	10000.0	Ship Fever And Other Stories
+504	David Bradley	David	Bradley	Q5231656	David Bradley	115793286	n80160307	male	University of Pennsylvania	graduate				judge	National Book Foundation	National Book Award	1996	prose	book	10000.0	Ship Fever And Other Stories
 226	Benjamin Cheever	Benjamin	Cheever	Q4888391	Benjamin Cheever	37015415	n88014705	male						judge	National Book Foundation	National Book Award	1996	prose	book	10000.0	Ship Fever And Other Stories
 1887	Reginald McKnight	Reginald	McKnight	Q7308811	Reginald McKnight	56665078	n87943412	male		graduate				judge	National Book Foundation	National Book Award	2008	prose	book	10000.0	Shadow Country
 1825	Peter Matthiessen	Peter	Matthiessen	Q892108	Peter Matthiessen	14773612	n50006569	male	Yale University					winner	National Book Foundation	National Book Award	2008	prose	book	10000.0	Shadow Country
@@ -837,17 +837,17 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1430	Louis Untermeyer	Louis	Untermeyer	Q1872015	Louis Untermeyer	39541598	n79054344	male						judge	National Book Foundation	National Book Award	1950	poetry	book	10000.0	Selected Poems
 2005	Rolfe Humphries	Rolfe	Humphries	Q7360825	Rolfe Humphries	79410283	n50034126	male						judge	National Book Foundation	National Book Award	1964	poetry	book	10000.0	Selected Poems
 2315	W. H. Auden	W. H.	Auden	Q178698	W. H. Auden	2465832	n79054316	male						judge	National Book Foundation	National Book Award	1950	poetry	book	10000.0	Selected Poems
-2157	Stewart Justman	Stewart	Justman					male	Columbia University	graduate				winner	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	2004	prose	book	15000.0	Seeds Of Mortality: The Public and Private Worlds of Cancer
-504	David Bradley	David	Bradley					male	University of Pennsylvania	graduate				winner	PEN America	Faulkner Award for Fiction	1982	prose	book	15000.0	Seaview
+2157	Stewart Justman	Stewart	Justman			107593995	n90683268	male	Columbia University	graduate				winner	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	2004	prose	book	15000.0	Seeds Of Mortality: The Public and Private Worlds of Cancer
+504	David Bradley	David	Bradley	Q5231656	David Bradley	115793286	n80160307	male	University of Pennsylvania	graduate				winner	PEN America	Faulkner Award for Fiction	1982	prose	book	15000.0	Seaview
 1134	John Hawkes	John	Hawkes	Q2627935	John Hawkes	109163993	n79011261	male	Harvard University					judge	PEN America	Faulkner Award for Fiction	1982	prose	book	15000.0	Seaview
 2317	Walker Percy	Walker	Percy	Q176909	Walker Percy	29539039	n80030460	male						judge	PEN America	Faulkner Award for Fiction	1982	prose	book	15000.0	Seaview
 2340	Wesley Brown	Wesley	Brown	Q85814970	Wesley Brown			male						judge	PEN America	Faulkner Award for Fiction	1982	prose	book	15000.0	Seaview
 1854	R. S. Gwynn	R. S.	Gwynn	Q7273965	R. S. Gwynn	44348544	n85204390	male		graduate	University of Arkansas			judge	National Book Foundation	National Book Award	1996	poetry	book	10000.0	Scrambled Eggs & Whiskey: Poems, 1991-1995
 2403	Yusef Komunyakaa	Yusef	Komunyakaa	Q2601996	Yusef Komunyakaa	32006129	n82203462	male		graduate	Univeristy of California, Irvine			judge	National Book Foundation	National Book Award	1996	poetry	book	10000.0	Scrambled Eggs & Whiskey: Poems, 1991-1995
-2371	William Matthews	William	Matthews					male	Yale University	graduate				judge	National Book Foundation	National Book Award	1996	poetry	book	10000.0	Scrambled Eggs & Whiskey: Poems, 1991-1995
+2371	William Matthews	William	Matthews	Q8015241	William Matthews	56838912	n78092891	male	Yale University	graduate				judge	National Book Foundation	National Book Award	1996	poetry	book	10000.0	Scrambled Eggs & Whiskey: Poems, 1991-1995
 869	Hayden Carruth	Hayden	Carruth	Q4357709	Hayden Carruth	79047287	n50032361	male	University of Chicago	graduate				winner	National Book Foundation	National Book Award	1996	poetry	book	10000.0	Scrambled Eggs & Whiskey: Poems, 1991-1995
 1037	Jefferson Fletcher	Jefferson	Fletcher					male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1929	prose	book	15000.0	Scarlet Sister Mary
-1897	Richard Burton	Richard	Burton	Q125057	Richard Francis Burton	29832058	n80057204	male		graduate				judge	Columbia University	Pulitzer Prize	1929	prose	book	15000.0	Scarlet Sister Mary
+1897	Richard Burton	Richard	Burton	Q84554359	Richard Burton	16015250	n50033772	male		graduate				judge	Columbia University	Pulitzer Prize	1929	prose	book	15000.0	Scarlet Sister Mary
 1971	Robert Lovett	Robert	Lovett					male	Harvard University					judge	Columbia University	Pulitzer Prize	1929	prose	book	15000.0	Scarlet Sister Mary
 1586	Matthew Klam	Matthew	Klam	Q6790814	Matthew Klam	49436996	n99263013	male		graduate	Hollins College			winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2002	prose	book	25000.0	Sam The Cat And Other Stories
 352	Charles Harper Webb	Charles Harper	Webb	Q5078789	Charles Harper Webb	36077392	n90663599	male		graduate	University of Southern California			judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2007	poetry	book	100000.0	Salvation Blues
@@ -861,9 +861,9 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1843	Philip Roth	Philip	Roth	Q187019	Philip Roth	100235370	n79125808	male	University of Chicago	graduate				winner	National Book Foundation	National Book Award	1995	prose	book	10000.0	Sabbath's Theater
 1636	Michael Malone	Michael	Malone	Q2387077	Michael Malone	111690466	n79145347	male		graduate				judge	National Book Foundation	National Book Award	1995	prose	book	10000.0	Sabbath's Theater
 1535	Mark Richard	Mark	Richard	Q6769414	Mark Richard	102381015	n88073301	male						judge	National Book Foundation	National Book Award	1995	prose	book	10000.0	Sabbath's Theater
-391	Christopher Brookhouse	Christopher	Brookhouse					male	Stanford University, Harvard University	graduate				winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1971	prose	book	10000.0	Running Out
+391	Christopher Brookhouse	Christopher	Brookhouse			91274523	n50041280	male	Stanford University, Harvard University	graduate				winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1971	prose	book	10000.0	Running Out
 782	Garret Hongo	Garret	Hongo					male		graduate	Univeristy of California, Irvine			judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1996	poetry	book	100000.0	Rough Music
-1100	John (Jack) Miles	John (Jack)	Miles					male	Harvard University	graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1996	poetry	book	100000.0	Rough Music
+1100	John (Jack) Miles	John (Jack)	Miles	Q45963	Jack Miles	24716819	n94067984	male	Harvard University	graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1996	poetry	book	100000.0	Rough Music
 1680	Murray Schwartz	Murray	Schwartz					male		graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1996	poetry	book	100000.0	Rough Music
 470	Daniel Halpern	Daniel	Halpern	Q55941553	Daniel Halpern	110940158	n50018478	male	Columbia University					judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1996	poetry	book	100000.0	Rough Music
 1594	Maurice Dolbier	Maurice	Dolbier					male						judge	Columbia University	Pulitzer Prize	1977	prose	book	15000.0	Roots
@@ -882,13 +882,13 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 15	Adam Johnson	Adam	Johnson	Q4679309	Adam Johnson	119126256	n2001039608	male	Stanford University	graduate	McNeese State University		Stegner	judge	National Book Foundation	National Book Award	2014	prose	book	10000.0	Redeployment
 1631	Michael Gorra	Michael	Gorra					male	Stanford University	graduate				judge	National Book Foundation	National Book Award	2014	prose	book	10000.0	Redeployment
 1835	Phil Klay	Phil	Klay	Q18026907	Phil Klay	305195285	n2013052397	male	Dartmouth College					winner	National Book Foundation	National Book Award	2014	prose	book	10000.0	Redeployment
-352	Charles Harper Webb	Charles Harper	Webb					male		graduate	University of Washington			winner	Claremont Graduate University	Kate Tufts Discovery Award 	1998	poetry	book	10000.0	Reading The Water
+352	Charles Harper Webb	Charles Harper	Webb	Q5078789		36077392	n90663599	male		graduate	University of Washington			winner	Claremont Graduate University	Kate Tufts Discovery Award 	1998	poetry	book	10000.0	Reading The Water
 782	Garret Hongo	Garret	Hongo					male		graduate	Univeristy of California, Irvine			judge	Claremont Graduate University	Kate Tufts Discovery Award 	1998	poetry	book	10000.0	Reading The Water
 787	Gary Soto	Gary	Soto	Q5525966	Gary Soto	24617649	n80082328	male		graduate	Univeristy of California, Irvine			judge	Claremont Graduate University	Kate Tufts Discovery Award 	1998	poetry	book	10000.0	Reading The Water
-1100	John (Jack) Miles	John (Jack)	Miles					male	Harvard University	graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	1998	poetry	book	10000.0	Reading The Water
+1100	John (Jack) Miles	John (Jack)	Miles	Q45963	Jack Miles	24716819	n94067984	male	Harvard University	graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	1998	poetry	book	10000.0	Reading The Water
 470	Daniel Halpern	Daniel	Halpern	Q55941553	Daniel Halpern	110940158	n50018478	male	Columbia University					judge	Claremont Graduate University	Kate Tufts Discovery Award 	1998	poetry	book	10000.0	Reading The Water
 887	Herb Liebowitz	Herb	Liebowitz					male						judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1993	poetry	book	100000.0	Rapture
-1100	John (Jack) Miles	John (Jack)	Miles					male	Harvard University	graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1993	poetry	book	100000.0	Rapture
+1100	John (Jack) Miles	John (Jack)	Miles	Q45963	Jack Miles	24716819	n94067984	male	Harvard University	graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1993	poetry	book	100000.0	Rapture
 1680	Murray Schwartz	Murray	Schwartz					male		graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1993	poetry	book	100000.0	Rapture
 1822	Peter Davison	Peter	Davison	Q7173576	Peter Davison	64018487	n80061240	male	Harvard University					judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1993	poetry	book	100000.0	Rapture
 2199	Ted Genoways	Ted	Genoways	Q15451922	Ted Genoways	251903	n94105509	male		graduate	University of Virginia			judge	Claremont Graduate University	Kate Tufts Discovery Award 	2012	poetry	book	10000.0	Radial Symmetry
@@ -947,18 +947,18 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1122	John Edgar Wideman	John Edgar	Wideman	Q688739	John Edgar Wideman	110405033	n82231445	male	University of Pennsylvania	graduate	University of Iowa	missing		winner	PEN America	Faulkner Award for Fiction	1991	prose	book	15000.0	Philadelphia Fire
 1812	Percival Everett	Percival	Everett	Q3375158	Percival Everett	120212810	n83043473	male	Brown University	graduate	Brown University			judge	PEN America	Faulkner Award for Fiction	1991	prose	book	15000.0	Philadelphia Fire
 1259	Karl Kirchway	Karl	Kirchway					male	Yale University, Columbia University	graduate				judge	National Book Foundation	National Book Award	1995	poetry	book	10000.0	Passing Through: The Later Poems, New And Selected
-1981	Robert Phillips	Robert	Phillips					male	Yale University	graduate				judge	National Book Foundation	National Book Award	1995	poetry	book	10000.0	Passing Through: The Later Poems, New And Selected
+1981	Robert Phillips	Robert	Phillips	Q7348886	Robert Phillips	108961346	n78096860	male	Yale University	graduate				judge	National Book Foundation	National Book Award	1995	poetry	book	10000.0	Passing Through: The Later Poems, New And Selected
 2128	Stanley Kunitz	Stanley	Kunitz	Q1974852	Stanley Kunitz	109638294	n79007720	male	Harvard University	graduate				winner	National Book Foundation	National Book Award	1995	poetry	book	10000.0	Passing Through: The Later Poems, New And Selected
 1205	Joseph Bruchac	Joseph	Bruchac	Q1706690	Joseph Bruchac	29521034	n79042033	male	Cornell University	graduate				judge	National Book Foundation	National Book Award	1995	poetry	book	10000.0	Passing Through: The Later Poems, New And Selected
 780	Galway Kinnell	Galway	Kinnell	Q2425705	Galway Kinnell	36939820	n78095426	male	Princeton University	graduate				judge	Columbia University	Pulitzer Prize	1988	poetry	book	15000.0	Partial Accounts: New And Selected Poems
 2373	William Meredith	William	Meredith					male	Princeton University					winner	Columbia University	Pulitzer Prize	1988	poetry	book	15000.0	Partial Accounts: New And Selected Poems
 1263	Karl Shapiro	Karl	Shapiro	Q2906282	Karl Shapiro	109257053	n79021704	male						judge	Columbia University	Pulitzer Prize	1988	poetry	book	15000.0	Partial Accounts: New And Selected Poems
-1439	Loyd Little	Loyd	Little					male						winner	PEN America	Hemingway Award for Debut Novel	1976	prose	book	10000.0	Parthian Shot
+1439	Loyd Little	Loyd	Little			16408126	n91076042	male						winner	PEN America	Hemingway Award for Debut Novel	1976	prose	book	10000.0	Parthian Shot
 267	Brad Leithauser	Brad	Leithauser	Q896817	Brad Leithauser	94522244	n81126641	male	Harvard University	graduate				judge	National Book Foundation	National Book Award	1988	prose	book	10000.0	Paris Trout
 354	Charles Johnson	Charles	Johnson	Q1065092	Charles Johnson	4098150567615706370002	n86836122	male		graduate				judge	National Book Foundation	National Book Award	1988	prose	book	10000.0	Paris Trout
 1093	Joe Conarroe	Joe	Conarroe					male		graduate				judge	National Book Foundation	National Book Award	1988	prose	book	10000.0	Paris Trout
 1814	Pete Dexter	Pete	Dexter	Q458445	Pete Dexter	110920531	n83164416	male						winner	National Book Foundation	National Book Award	1988	prose	book	10000.0	Paris Trout
-1327	Kirk Nesset	Kirk	Nesset					male		graduate				winner	University of Pittsburg Press	Drue Heinz Literature Prize	2007	prose	book	15000.0	Paradise Road
+1327	Kirk Nesset	Kirk	Nesset			39533816	n94066257	male		graduate				winner	University of Pittsburg Press	Drue Heinz Literature Prize	2007	prose	book	15000.0	Paradise Road
 896	Hilary Masters	Hilary	Masters	Q3785608	Hilary Masters	33110744	n82040056	male	Brown University					judge	University of Pittsburg Press	Drue Heinz Literature Prize	2007	prose	book	15000.0	Paradise Road
 1900	Richard Eder	Richard	Eder	Q7325431	Richard Eder	4122149068408765730003	n97867058	male	Harvard University					judge	National Book Foundation	National Book Award	1987	prose	book	10000.0	Paco's Story
 1345	Larry Heinemann	Larry	Heinemann	Q6490488	Larry Heinemann	4958369	n85339740	male						winner	National Book Foundation	National Book Award	1987	prose	book	10000.0	Paco's Story
@@ -985,7 +985,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 448	D. A. Powell	D. A.	Powell	Q5203478	D. A. Powell	28821341	n97105916	male		graduate	University of Iowa	2263		judge	Academy of American Poets	Lenore Marshall Poetry Prize	2011	poetry	book	25000.0	One With Others
 1037	Jefferson Fletcher	Jefferson	Fletcher					male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1923	prose	book	15000.0	One Of Ours
 256	Bliss Perry	Bliss	Perry	Q4926866	Bliss Perry	76448095	n50009730	male		graduate				judge	Columbia University	Pulitzer Prize	1923	prose	book	15000.0	One Of Ours
-2049	Samuel Crothers	Samuel	Crothers					male						judge	Columbia University	Pulitzer Prize	1923	prose	book	15000.0	One Of Ours
+2049	Samuel Crothers	Samuel	Crothers	Q7412138	Samuel McChord Crothers	66604792	n50057777	male						judge	Columbia University	Pulitzer Prize	1923	prose	book	15000.0	One Of Ours
 522	David Kennedy	David	Kennedy	Q1975383	David A. Kennedy	104825600		male	Stanford University, Yale University	graduate				judge	Columbia University	Pulitzer Prize	2009	prose	book	15000.0	Olive Kitteridge
 1853	R. H. W. Dillard	R. H. W.	Dillard	Q7273681	R. H. W. Dillard	110113587	n50025521	male		graduate				judge	Columbia University	Pulitzer Prize	2009	prose	book	15000.0	Olive Kitteridge
 2282	Tyehimba Jess	Tyehimba	Jess	Q15441431	Tyehimba Jess	58785478	no2004014919	male	University of Chicago	graduate	New York University			winner	Columbia University	Pulitzer Prize	2017	poetry	book	15000.0	Olio
@@ -1010,14 +1010,14 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2307	Vinson Cunningham	Vinson	Cunningham	Q109553275	Vinson Cunningham			male						judge	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	2018	prose	book	15000.0	No Time to Spare: Thinking about what Matters
 1173	John Yau	John	Yau	Q1702239	John Yau	32010539	n80031848	male		graduate	Brooklyn College			judge	Academy of American Poets	Lenore Marshall Poetry Prize	2010	poetry	book	25000.0	Ninety-Fifth Street
 1147	John Koethe	John	Koethe	Q6243383	John Koethe	119169637	n84038771	male	Princeton University, Harvard University	graduate				winner	Academy of American Poets	Lenore Marshall Poetry Prize	2010	poetry	book	25000.0	Ninety-Fifth Street
-523	David Kirby	David	Kirby	Q15486802	David Kirby	102379161	n79079287	male		graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	2010	poetry	book	25000.0	Ninety-Fifth Street
+523	David Kirby	David	Kirby	Q5236033	David Kirby	101408343	n2009067554	male		graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	2010	poetry	book	25000.0	Ninety-Fifth Street
 907	Howard Nemerov	Howard	Nemerov	Q429011	Howard Nemerov	68933459	n78084908	male	Harvard University	graduate				judge	National Book Foundation	National Book Award	1967	poetry	book	10000.0	Nights And Days
 1537	Mark Schorer	Mark	Schorer	Q6769632	Mark Schorer	6174258	n50002798	male	Harvard University	graduate				judge	National Book Foundation	National Book Award	1967	poetry	book	10000.0	Nights And Days
 178	Anthony West	Anthony	West	Q2852999	Anthony West	20204315	n50003452	male						judge	National Book Foundation	National Book Award	1967	poetry	book	10000.0	Nights And Days
 966	James Dickey	James	Dickey	Q1377013	James Dickey	109230203	n79043450	male						judge	National Book Foundation	National Book Award	1967	poetry	book	10000.0	Nights And Days
 982	James Merrill	James	Merrill	Q1368437	James Merrill	73866527	n80026113	male						winner	National Book Foundation	National Book Award	1967	poetry	book	10000.0	Nights And Days
 1141	John Hutch	John	Hutch					male						judge	National Book Foundation	National Book Award	1967	poetry	book	10000.0	Nights And Days
-936	Ivan Gold	Ivan	Gold	Q110940850	Ivan Gold	539182		male	Columbia University					winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1964	prose	book	10000.0	Nickel Miseries
+936	Ivan Gold	Ivan	Gold	Q110940850	Ivan Gold	539182	n90639000	male	Columbia University					winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1964	prose	book	10000.0	Nickel Miseries
 2257	Todd James Pierce	Todd James	Pierce	Q7812458	Todd James Pierce	53509593	n2002047466	male		graduate	Univeristy of California, Irvine			winner	University of Pittsburg Press	Drue Heinz Literature Prize	2006	prose	book	15000.0	Newsworld
 941	J. D. McClatchy	J. D.	McClatchy	Q915445	J. D. McClatchy	98044618	n77011314	male	Yale University	graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	1986	poetry	book	25000.0	New Selected Poems
 1904	Richard Howard	Richard	Howard	Q2636383	Richard Howard	73940071	n79066341	male	Columbia University	graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	1986	poetry	book	25000.0	New Selected Poems
@@ -1032,7 +1032,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 591	Donald Hall	Donald	Hall	Q976924	Donald Hall	49226675	n79043673	male	Harvard University, Stanford University	graduate			Stegner	judge	National Book Foundation	National Book Award	1992	poetry	book	10000.0	New And Selected Poems (Vol 1 Of Two)
 721	Eugene Gloria	Eugene	Gloria	Q5407308	Eugene Gloria	46097995	n99260511	male		graduate	University of Oregon			judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2005	poetry	book	100000.0	New And Selected Poems
 1988	Robert Wrigley	Robert	Wrigley	Q7351272	Robert Wrigley	52952040	n78090918	male		graduate	University of Montana			judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2005	poetry	book	100000.0	New And Selected Poems
-1641	Michael Ryan	Michael	Ryan					male		graduate	University of Iowa	missing		winner	Claremont Graduate University	Kingsley Tufts Poetry Award	2005	poetry	book	100000.0	New And Selected Poems
+1641	Michael Ryan	Michael	Ryan	Q6834055	Michael Ryan	7620757	n80090635	male		graduate	University of Iowa	missing		winner	Claremont Graduate University	Kingsley Tufts Poetry Award	2005	poetry	book	100000.0	New And Selected Poems
 1982	Robert Pinsky	Robert	Pinsky	Q588807	Robert Pinsky	79069348	n83039273	male	Stanford University	graduate			Stegner	judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2005	poetry	book	100000.0	New And Selected Poems
 1918	Richard Wilbur	Richard	Wilbur	Q1333582	Richard Wilbur	14804371	n79007244	male	Harvard University	graduate				winner	Columbia University	Pulitzer Prize	1989	poetry	book	15000.0	New And Collected Poems
 799	George Core	George	Core					male		graduate				judge	Columbia University	Pulitzer Prize	1989	poetry	book	15000.0	New And Collected Poems
@@ -1043,7 +1043,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1632	Michael Harper	Michael	Harper					male		graduate	University of Iowa	3195		judge	Columbia University	Pulitzer Prize	1994	poetry	book	15000.0	Neon Vernacular: New And Selected Poems
 2403	Yusef Komunyakaa	Yusef	Komunyakaa	Q2601996	Yusef Komunyakaa	32006129	n82203462	male		graduate	Univeristy of California, Irvine			winner	Claremont Graduate University	Kingsley Tufts Poetry Award	1994	poetry	book	100000.0	Neon Vernacular: New And Selected Poems
 2403	Yusef Komunyakaa	Yusef	Komunyakaa	Q2601996	Yusef Komunyakaa	32006129	n82203462	male		graduate	Univeristy of California, Irvine			winner	Columbia University	Pulitzer Prize	1994	poetry	book	15000.0	Neon Vernacular: New And Selected Poems
-1100	John (Jack) Miles	John (Jack)	Miles					male	Harvard University	graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1994	poetry	book	100000.0	Neon Vernacular: New And Selected Poems
+1100	John (Jack) Miles	John (Jack)	Miles	Q45963	Jack Miles	24716819	n94067984	male	Harvard University	graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1994	poetry	book	100000.0	Neon Vernacular: New And Selected Poems
 307	Calvin Bedient	Calvin	Bedient	Q107643012	Calvin Bedient	76333351	n83312283	male		graduate				judge	Columbia University	Pulitzer Prize	1994	poetry	book	15000.0	Neon Vernacular: New And Selected Poems
 1680	Murray Schwartz	Murray	Schwartz					male		graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1994	poetry	book	100000.0	Neon Vernacular: New And Selected Poems
 1822	Peter Davison	Peter	Davison	Q7173576	Peter Davison	64018487	n80061240	male	Harvard University					judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1994	poetry	book	100000.0	Neon Vernacular: New And Selected Poems
@@ -1056,13 +1056,13 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2344	Wilbur L. Cross	Wilbur L.	Cross					male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1946	poetry	book	15000.0	No Winner
 231	Benjamine Demott	Benjamine	Demott					male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1974	prose	book	15000.0	No Winner
 314	Carlos Baker	Carlos	Baker	Q5041809	Carlos Baker	107027003	n50020883	male	Dartmouth College, Harvard University, Princeton University	graduate				judge	Columbia University	Pulitzer Prize	1957	prose	book	15000.0	No Winner
-745	Francis Brown	Francis	Brown					male	Dartmouth College, Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1957	prose	book	15000.0	No Winner
+745	Francis Brown	Francis	Brown	Q60150800	Francis Brown	57461376	n50039648	male	Dartmouth College, Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1957	prose	book	15000.0	No Winner
 1419	Lon Tinkle	Lon	Tinkle	Q6669619	Lon Tinkle	8627957	n50011856	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1971	prose	book	15000.0	No Winner
 1604	Maxwell Geismar	Maxwell	Geismar	Q6796102	Maxwell Geismar	32932096	n50018262	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1964	prose	book	15000.0	No Winner
 1604	Maxwell Geismar	Maxwell	Geismar	Q6796102	Maxwell Geismar	32932096	n50018262	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1946	prose	book	15000.0	No Winner
 48	Albert Duhamel	Albert	Duhamel					male		graduate				judge	Columbia University	Pulitzer Prize	1971	prose	book	15000.0	No Winner
-1115	John Chamberlain	John	Chamberlain	Q6225650	John Chamberlain	39748463	nr90005975	male	Yale University					judge	Columbia University	Pulitzer Prize	1946	prose	book	15000.0	No Winner
-1390	Lewis Gannett	Lewis	Gannett	Q6536574	Lewis Gannett			male	Harvard University					judge	Columbia University	Pulitzer Prize	1964	prose	book	15000.0	No Winner
+1115	John Chamberlain	John	Chamberlain	Q6225652	John Chamberlain	3841537	n83021282	male	Yale University					judge	Columbia University	Pulitzer Prize	1946	prose	book	15000.0	No Winner
+1390	Lewis Gannett	Lewis	Gannett	Q62224679	Lewis Gannett	11462821	n90622248	male	Harvard University					judge	Columbia University	Pulitzer Prize	1964	prose	book	15000.0	No Winner
 69	Alfred Kazin	Alfred	Kazin	Q2529254	Alfred Kazin	108771008	n79038435	male						judge	Columbia University	Pulitzer Prize	1974	prose	book	15000.0	No Winner
 1430	Louis Untermeyer	Louis	Untermeyer	Q1872015	Louis Untermeyer	39541598	n79054344	male						judge	Columbia University	Pulitzer Prize	1946	poetry	book	15000.0	No Winner
 1752	Orville Prescott	Orville	Prescott	Q7105248	Orville Prescott	237553275	n50028227	male						judge	Columbia University	Pulitzer Prize	1946	prose	book	15000.0	No Winner
@@ -1082,7 +1082,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 943	J. F. Powers	J. F.	Powers	Q1369803	J. F. Powers	110146339	n79063855	male						winner	National Book Foundation	National Book Award	1963	prose	book	10000.0	Morte D'Urban
 864	Harry Levin	Harry	Levin	Q3616156	Harry Levin	85171640	n80037015	male	Harvard University					judge	National Book Foundation	National Book Award	1963	prose	book	10000.0	Morte D'Urban
 829	Gore Vidal	Gore	Vidal	Q167821	Gore Vidal	98281411	n79040150	male						judge	National Book Foundation	National Book Award	1963	prose	book	10000.0	Morte D'Urban
-44	Alan Saperstein	Alan	Saperstein					male						winner	PEN America	Hemingway Award for Debut Novel	1980	prose	book	10000.0	Mom Kills Kids And Self
+44	Alan Saperstein	Alan	Saperstein			43108327	n79027434	male						winner	PEN America	Hemingway Award for Debut Novel	1980	prose	book	10000.0	Mom Kills Kids And Self
 352	Charles Harper Webb	Charles Harper	Webb	Q5078789	Charles Harper Webb	36077392	n90663599	male		graduate	University of Southern California			judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2009	poetry	book	100000.0	Modern Life
 1982	Robert Pinsky	Robert	Pinsky	Q588807	Robert Pinsky	79069348	n83039273	male	Stanford University	graduate			Stegner	judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2009	poetry	book	100000.0	Modern Life
 1793	Paul Muldoon	Paul	Muldoon	Q2061388	Paul Muldoon	64048541	n81098944	male						judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2009	poetry	book	100000.0	Modern Life
@@ -1143,7 +1143,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1683	N. Scott Momaday	N. Scott	Momaday	Q736570	N. Scott Momaday	110439963	n50003752	male	Stanford University	graduate			Stegner	judge	Columbia University	Pulitzer Prize	1986	prose	book	15000.0	Lonesome Dove
 1899	Richard Eberhart	Richard	Eberhart	Q975736	Richard Eberhart	97788157	n81027817	male	Dartmouth College	graduate				judge	Columbia University	Pulitzer Prize	1967	poetry	book	15000.0	Live Or Die
 1429	Louis Simpson	Louis	Simpson	Q1871997	Louis Simpson	7509913	n50023694	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1967	poetry	book	15000.0	Live Or Die
-2217	Thomas Berger	Thomas	Berger					male		graduate	New School for Social Research			winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1965	prose	book	10000.0	Little Big Man
+2217	Thomas Berger	Thomas	Berger	Q21055929	Thomas Berger	116326922	n2016041110	male		graduate	New School for Social Research			winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1965	prose	book	10000.0	Little Big Man
 1927	Rick Hillis	Rick	Hillis	Q7331458	Rick Hillis	44332932	n90616430	male	Stanford University	graduate	University of Iowa	1525	Stegner	winner	University of Pittsburg Press	Drue Heinz Literature Prize	1990	prose	book	15000.0	Limbo River
 2031	Russell Banks	Russell	Banks	Q665144	Russell Banks	66487364	n79131992	male						judge	University of Pittsburg Press	Drue Heinz Literature Prize	1990	prose	book	15000.0	Limbo River
 431	Cornelius Eady	Cornelius	Eady	Q5171355	Cornelius Eady	77765819	n85266803	male		graduate	Warren Wilson College			judge	National Book Foundation	National Book Award	2010	poetry	book	10000.0	Lighthead
@@ -1152,7 +1152,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1125	John Frederick Nimas	John Frederick	Nimas					male	University of Chicago	graduate				judge	National Book Foundation	National Book Award	1982	poetry	book	10000.0	Life Supports: New And Collected Poems
 1836	Philip Booth	Philip	Booth	Q7183246	Philip Booth	91266393	n80057320	male	Dartmouth College, Columbia University	graduate				judge	National Book Foundation	National Book Award	1982	poetry	book	10000.0	Life Supports: New And Collected Poems
 743	Frances Lindley	Frances	Lindley					male		graduate				judge	National Book Foundation	National Book Award	1982	poetry	book	10000.0	Life Supports: New And Collected Poems
-1917	Richard Weaver	Richard	Weaver					male		graduate				judge	National Book Foundation	National Book Award	1982	poetry	book	10000.0	Life Supports: New And Collected Poems
+1917	Richard Weaver	Richard	Weaver	Q2483598	Richard M. Weaver	10649913	n50023763	male		graduate				judge	National Book Foundation	National Book Award	1982	poetry	book	10000.0	Life Supports: New And Collected Poems
 1952	Robert Creeley	Robert	Creeley	Q918620	Robert Creeley	109562114	n79043504	male		graduate				judge	National Book Foundation	National Book Award	1982	poetry	book	10000.0	Life Supports: New And Collected Poems
 2358	William Bronk	William	Bronk	Q264694	William Bronk	79048234	n50040537	male	Dartmouth College					winner	National Book Foundation	National Book Award	1982	poetry	book	10000.0	Life Supports: New And Collected Poems
 975	James Johnson Sweeney	James Johnson	Sweeney					male						judge	National Book Foundation	National Book Award	1960	poetry	book	10000.0	Life Studies
@@ -1182,11 +1182,11 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 51	Albert Paine	Albert	Paine	Q4710951	Albert Paine	24731419	n80089241	male						judge	Columbia University	Pulitzer Prize	1934	prose	book	15000.0	Lamb In His Bosom
 1262	Karl Marlantes	Karl	Marlantes	Q2038095	Karl Marlantes	106896414	no2010010196	male	Yale University	graduate				judge	Center for Fiction	First Novel Prize	2011	prose	book	15000.0	Lamb
 750	Francisco Goldman	Francisco	Goldman	Q3081853	Francisco Goldman	66622790	n91124480	male		graduate				judge	Center for Fiction	First Novel Prize	2011	prose	book	15000.0	Lamb
-40	Alan Hewat	Alan	Hewat					male						winner	PEN America	Hemingway Award for Debut Novel	1986	prose	book	10000.0	Lady's Time
+40	Alan Hewat	Alan	Hewat			1424064	n84211292	male						winner	PEN America	Hemingway Award for Debut Novel	1986	prose	book	10000.0	Lady's Time
 595	Donald Ray Pollock	Donald Ray	Pollock	Q1240267	Donald Ray Pollock	53606234	n2007069632	male						winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2009	prose	book	25000.0	Knockemstiff
 612	Douglas Day	Douglas	Day	Q5301407	Douglas Day	94392126	n50035210	male		graduate				winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1978	prose	book	10000.0	Journey Of The Wolf
 1604	Maxwell Geismar	Maxwell	Geismar	Q6796102	Maxwell Geismar	32932096	n50018262	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1944	prose	book	15000.0	Journey In The Dark
-1115	John Chamberlain	John	Chamberlain	Q6225650	John Chamberlain	39748463	nr90005975	male	Yale University					judge	Columbia University	Pulitzer Prize	1944	prose	book	15000.0	Journey In The Dark
+1115	John Chamberlain	John	Chamberlain	Q6225652	John Chamberlain	3841537	n83021282	male	Yale University					judge	Columbia University	Pulitzer Prize	1944	prose	book	15000.0	Journey In The Dark
 1553	Martin Flavin	Martin	Flavin	Q503483	Martin Flavin	77845843	n87896318	male	University of Chicago					winner	Columbia University	Pulitzer Prize	1944	prose	book	15000.0	Journey In The Dark
 1390	Lewis Gannett	Lewis	Gannett	Q62224679	Lewis Gannett	11462821	n90622248	male	Harvard University					judge	Columbia University	Pulitzer Prize	1944	prose	book	15000.0	Journey In The Dark
 2145	Stephen Vincent Benét	Stephen Vincent	Benét	Q1348138	Stephen Vincent Benét	100260717	n50007691	male	Yale University	graduate				winner	Columbia University	Pulitzer Prize	1929	poetry	book	15000.0	John Brown's Body
@@ -1196,9 +1196,9 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1594	Maurice Dolbier	Maurice	Dolbier					male						judge	National Book Foundation	National Book Award	1976	prose	book	10000.0	J R
 2363	William Gass	William	Gass	Q304874	William H. Gass	108798167	n79096948	male	Cornell University	graduate				judge	National Book Foundation	National Book Award	1976	prose	book	10000.0	J R
 2362	William Gaddis	William	Gaddis	Q456958	William Gaddis	109910493	n81043116	male						winner	National Book Foundation	National Book Award	1976	prose	book	10000.0	J R
-2219	Thomas Edwards	Thomas	Edwards	Q1767904	Twm o'r Nant	33479973	n86085771	male						judge	Columbia University	Pulitzer Prize	1984	prose	book	15000.0	Ironweed
+2219	Thomas Edwards	Thomas	Edwards	Q20734437	Thomas Edwards			male						judge	Columbia University	Pulitzer Prize	1984	prose	book	15000.0	Ironweed
 2378	William Robertson	William	Robertson	Q1113461	William Robertson	59177542	n50049179	male						judge	Columbia University	Pulitzer Prize	1984	prose	book	15000.0	Ironweed
-504	David Bradley	David	Bradley					male	University of Pennsylvania	graduate				judge	Columbia University	Pulitzer Prize	1984	prose	book	15000.0	Ironweed
+504	David Bradley	David	Bradley	Q5231656	David Bradley	115793286	n80160307	male	University of Pennsylvania	graduate				judge	Columbia University	Pulitzer Prize	1984	prose	book	15000.0	Ironweed
 2367	William Kennedy	William	Kennedy	Q31984	William Kennedy	109902833	n50045355	male						winner	Columbia University	Pulitzer Prize	1984	prose	book	15000.0	Ironweed
 1982	Robert Pinsky	Robert	Pinsky	Q588807	Robert Pinsky	79069348	n83039273	male	Stanford University	graduate			Stegner	judge	Claremont Graduate University	Kate Tufts Discovery Award 	2001	poetry	book	10000.0	Invisible Tender
 208	B. H. Fairchild	B. H.	Fairchild	Q4834012	B. H. Fairchild	75149721	n80062669	male		graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	2001	poetry	book	10000.0	Invisible Tender
@@ -1214,7 +1214,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1298	Keaton Patterson	Keaton	Patterson					male		graduate				judge	National Book Foundation	National Book Award	2020	prose	book	10000.0	Interior China Town
 365	Charles Yu	Charles	Yu	Q5083786	Charles Yu	76104238	no2007114091	male						winner	National Book Foundation	National Book Award	2020	prose	book	10000.0	Interior China Town
 1938	Rion Amilcar Scott	Rion Amilcar	Scott	Q50825635	Rion Amilcar Scott			male		graduate	George Mason University			winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2017	prose	book	25000.0	Insurrections
-206	Ayad Akhtar	Ayad	Akhtar					male	Brown University, Columbia University	graduate				judge	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2017	prose	book	25000.0	Insurrections
+206	Ayad Akhtar	Ayad	Akhtar	Q4830797	Ayad Akhtar	19124904	n2007001005	male	Brown University, Columbia University	graduate				judge	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2017	prose	book	25000.0	Insurrections
 182	Aravind Adiga	Aravind	Adiga	Q296299	Aravind Adiga	85852158	n2007079024	male	Columbia University					judge	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2017	prose	book	25000.0	Insurrections
 1901	Richard Ford	Richard	Ford	Q547794	Richard Ford	109503268	n80113050	male		graduate	Univeristy of California, Irvine			winner	PEN America	Faulkner Award for Fiction	1996	prose	book	15000.0	Independence Day
 1901	Richard Ford	Richard	Ford	Q547794	Richard Ford	109503268	n80113050	male		graduate	Univeristy of California, Irvine			winner	Columbia University	Pulitzer Prize	1996	prose	book	15000.0	Independence Day
@@ -1234,7 +1234,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 555	De'Shawn Charles Winslow	De'Shawn Charles	Winslow	Q120505975	De'Shawn Charles Winslow	22153651659655780451	n2018051868	male		graduate	University of Iowa	missing		winner	Center for Fiction	First Novel Prize	2019	prose	book	15000.0	In West Mills
 2267	Tommy Orange	Tommy	Orange 	Q63341394	Tommy Orange	1150940090326602893	n2017063987	male		graduate	Institute of American Indian Arts			judge	Center for Fiction	First Novel Prize	2019	prose	book	15000.0	In West Mills
 1037	Jefferson Fletcher	Jefferson	Fletcher					male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1942	prose	book	15000.0	In This Our Life
-1213	Joseph Krutch	Joseph	Krutch					male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1942	prose	book	15000.0	In This Our Life
+1213	Joseph Krutch	Joseph	Krutch	Q291183	Joseph Wood Krutch	49274843	n80007874	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1942	prose	book	15000.0	In This Our Life
 814	Gilbert Highet	Gilbert	Highet	Q1523989	Gilbert Highet	46807357	n83013861	male		graduate				judge	Columbia University	Pulitzer Prize	1942	prose	book	15000.0	In This Our Life
 2158	Stewart O'Nan	Stewart	O'Nan	Q1585875	Stewart O'Nan	34557524	n87839494	male	Cornell University	graduate	Cornell University			winner	University of Pittsburg Press	Drue Heinz Literature Prize	1993	prose	book	15000.0	In The Walled City
 2255	Tobias Wolff	Tobias	Wolff	Q495754	Tobias Wolff	99001261	n81010525	male	Stanford University	graduate			Stegner	judge	University of Pittsburg Press	Drue Heinz Literature Prize	1993	prose	book	15000.0	In The Walled City
@@ -1271,13 +1271,13 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 51	Albert Paine	Albert	Paine	Q4710951	Albert Paine	24731419	n80089241	male						judge	Columbia University	Pulitzer Prize	1936	prose	book	15000.0	Honey In The Horn
 1076	Jim Shepard	Jim	Shepard	Q6198081	Jim Shepard	39613753	n83121472	male	Brown University	graduate	Brown University			judge	PEN America	Hemingway Award for Debut Novel	2017	prose	book	10000.0	Homegoing
 1918	Richard Wilbur	Richard	Wilbur	Q1333582	Richard Wilbur	14804371	n79007244	male	Harvard University	graduate				judge	National Book Foundation	National Book Award	1969	poetry	book	10000.0	His Toy, His Dream, His Rest
-2354	William Alfred	William	Alfred					male	Harvard University	graduate				judge	National Book Foundation	National Book Award	1969	poetry	book	10000.0	His Toy, His Dream, His Rest
+2354	William Alfred	William	Alfred	Q8004294	William Alfred	53072398	n83208234	male	Harvard University	graduate				judge	National Book Foundation	National Book Award	1969	poetry	book	10000.0	His Toy, His Dream, His Rest
 1108	John Berryman	John	Berryman	Q522192	John Berryman	71421263	n79142591	male	Columbia University					winner	National Book Foundation	National Book Award	1969	poetry	book	10000.0	His Toy, His Dream, His Rest
 926	Irving Howe	Irving	Howe	Q728615	Irving Howe	108241502	n78096893	male						judge	National Book Foundation	National Book Award	1969	poetry	book	10000.0	His Toy, His Dream, His Rest
 1059	Jerre Mangione	Jerre	Mangione	Q3808008	Jerre Mangione	110176276	n81035550	male						judge	National Book Foundation	National Book Award	1969	poetry	book	10000.0	His Toy, His Dream, His Rest
 2374	William Pane	William	Pane					male						judge	Columbia University	Pulitzer Prize	1918	prose	book	15000.0	His Family 
 2376	William Phelps	William	Phelps					male	Yale University, Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1918	prose	book	15000.0	His Family 
-1961	Robert Grant	Robert	Grant	Q2157350	Robert Grant	261276674	n87896663	male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1918	prose	book	15000.0	His Family 
+1961	Robert Grant	Robert	Grant	Q7344917	Robert Grant	28317113	n50032020	male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1918	prose	book	15000.0	His Family 
 714	Ernest Poole	Ernest	Poole	Q782813	Ernest Cook Poole	18767628	n88071985	male	Princeton University					winner	Columbia University	Pulitzer Prize	1918	prose	book	15000.0	His Family 
 235	Bernard Malamud	Bernard	Malamud	Q351547	Bernard Malamud	34459928	n79046272	male	Columbia University	graduate				judge	National Book Foundation	National Book Award	1965	prose	book	10000.0	Herzog
 2073	Saul Bellow	Saul	Bellow	Q83059	Saul Bellow	27060791	n79078646	male		graduate				winner	National Book Foundation	National Book Award	1965	prose	book	10000.0	Herzog
@@ -1293,7 +1293,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1901	Richard Ford	Richard	Ford	Q547794	Richard Ford	109503268	n80113050	male		graduate	Univeristy of California, Irvine			judge	University of Pittsburg Press	Drue Heinz Literature Prize	1991	prose	book	15000.0	Have You Seen Me?
 751	Frank Bidart	Frank	Bidart	Q5485312	Frank Bidart	90719088	n83022171	male	Harvard University	graduate				winner	Columbia University	Pulitzer Prize	2018	poetry	book	15000.0	Half-Light: Collected Poems 1965-2016.
 500	David Baker	David	Baker	Q1173633	David Baker	103248740	n82056913	male		graduate				judge	Columbia University	Pulitzer Prize	2018	poetry	book	15000.0	Half-Light: Collected Poems 1965-2016.
-2223	Thomas Lynch	Thomas	Lynch	Q50825639	Thomas R. Lynch	175150468271404171606	n2017187071	male						judge	Columbia University	Pulitzer Prize	2018	poetry	book	15000.0	Half-Light: Collected Poems 1965-2016.
+2223	Thomas Lynch	Thomas	Lynch	Q7791998	Thomas Lynch	16229445	n85352998	male						judge	Columbia University	Pulitzer Prize	2018	poetry	book	15000.0	Half-Light: Collected Poems 1965-2016.
 836	Gregory Pardlo	Gregory	Pardlo	Q5607102	Gregory Pardlo	58819978	no2005087851	male		graduate	New York University			judge	National Book Foundation	National Book Award	2017	poetry	book	10000.0	Half-Light: Collected Poems 1965-2016
 1723	Nick Flynn	Nick	Flynn	Q15513166	Nick Flynn	61836155	n00030946	male		graduate	New York University			judge	National Book Foundation	National Book Award	2017	poetry	book	10000.0	Half-Light: Collected Poems 1965-2016
 751	Frank Bidart	Frank	Bidart	Q5485312	Frank Bidart	90719088	n83022171	male	Harvard University	graduate				winner	National Book Foundation	National Book Award	2017	poetry	book	10000.0	Half-Light: Collected Poems 1965-2016
@@ -1316,7 +1316,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 377	Chris Abani	Chris	Abani	Q1076935	Chris Abani	61872289	n85352636	male		graduate				winner	PEN America	Hemingway Award for Debut Novel	2005	prose	book	10000.0	Graceland
 908	Howard Norman	Howard	Norman	Q5920510	Howard Norman	118417991	n79012257	male		graduate				judge	PEN America	Hemingway Award for Debut Novel	2005	prose	book	10000.0	Graceland
 1843	Philip Roth	Philip	Roth	Q187019	Philip Roth	100235370	n79125808	male	University of Chicago	graduate				winner	National Book Foundation	National Book Award	1960	prose	book	10000.0	Goodbye, Columbus
-359	Charles Rolo	Charles	Rolo					male	Columbia University	graduate				judge	National Book Foundation	National Book Award	1960	prose	book	10000.0	Goodbye, Columbus
+359	Charles Rolo	Charles	Rolo	Q59630104	Charles James Rolo	69964446	n82020036	male	Columbia University	graduate				judge	National Book Foundation	National Book Award	1960	prose	book	10000.0	Goodbye, Columbus
 277	Brendan Gill	Brendan	Gill	Q908693	Brendan Gill	27827433	n50027762	male	Yale University					judge	National Book Foundation	National Book Award	1960	prose	book	10000.0	Goodbye, Columbus
 63	Alexander Laing	Alexander	Laing	Q55125254	Alexander Laing	36075714	n90650481	male	Dartmouth College					judge	National Book Foundation	National Book Award	1960	prose	book	10000.0	Goodbye, Columbus
 2375	William Peden	William	Peden	Q80633056	William Peden	64211296	n50008760	male						judge	National Book Foundation	National Book Award	1960	prose	book	10000.0	Goodbye, Columbus
@@ -1327,10 +1327,10 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 51	Albert Paine	Albert	Paine	Q4710951	Albert Paine	24731419	n80089241	male						judge	Columbia University	Pulitzer Prize	1937	prose	book	15000.0	Gone With The Wind
 2244	Tim O'Brien	Tim	O'Brien	Q1289151	Tim O'Brien	85364833	n85092953	male	Harvard University	graduate				winner	National Book Foundation	National Book Award	1979	prose	book	10000.0	Going After Cacciato
 2320	Wallace Stegner	Wallace	Stegner	Q203460	Wallace Stegner	110195864	n79021163	male		graduate				judge	National Book Foundation	National Book Award	1979	prose	book	10000.0	Going After Cacciato
-2093	Shawn Vestal	Shawn	Vestal	Q38235479	Shawn Vestal	292461252		male		graduate	Eastern Washington University			winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2014	prose	book	25000.0	Godforsaken Idaho
+2093	Shawn Vestal	Shawn	Vestal	Q38235479	Shawn Vestal	292461252	n2012076341	male		graduate	Eastern Washington University			winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2014	prose	book	25000.0	Godforsaken Idaho
 346	Charles Bock	Charles	Bock	Q2454262	Charles Bock	101002833	n2007010093	male		graduate	Bennington College			judge	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2014	prose	book	25000.0	Godforsaken Idaho
 1184	Jonathan Dee	Jonathan	Dee	Q3183344	Jonathan Dee	116935896	n90640191	male	Yale University					judge	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2014	prose	book	25000.0	Godforsaken Idaho
-1641	Michael Ryan	Michael	Ryan					male		graduate	University of Iowa	missing		winner	Academy of American Poets	Lenore Marshall Poetry Prize	1990	poetry	book	25000.0	God Hunger
+1641	Michael Ryan	Michael	Ryan	Q6834055	Michael Ryan	7620757	n80090635	male		graduate	University of Iowa	missing		winner	Academy of American Poets	Lenore Marshall Poetry Prize	1990	poetry	book	25000.0	God Hunger
 2377	William Pritchard	William	Pritchard					male	Harvard University	graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	1990	poetry	book	25000.0	God Hunger
 2188	Sydney Lea	Sydney	Lea	Q7660012	Sydney Lea	261235446	n79122866	male	Yale University					judge	Academy of American Poets	Lenore Marshall Poetry Prize	1990	poetry	book	25000.0	God Hunger
 522	David Kennedy	David	Kennedy	Q1975383	David A. Kennedy	104825600		male	Stanford University, Yale University	graduate				judge	Columbia University	Pulitzer Prize	2005	prose	book	15000.0	Gilead
@@ -1369,13 +1369,13 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2344	Wilbur L. Cross	Wilbur L.	Cross					male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1927	poetry	book	15000.0	Fiddler's Farewell
 738	Ferris Greenslet	Ferris	Greenslet	Q5445372	Ferris Greenslet	52768436	n88640081	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1927	poetry	book	15000.0	Fiddler's Farewell
 1124	John Erskine	John	Erskine	Q552067	John Erskine	100198296	n50012296	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1927	poetry	book	15000.0	Fiddler's Farewell
-487	Danny Santiago	Danny	Santiago					male	Yale University					winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1984	prose	book	10000.0	Famous All Over Town
+487	Danny Santiago	Danny	Santiago			270744246	n82162360	male	Yale University					winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1984	prose	book	10000.0	Famous All Over Town
 631	Edmund White	Edmund	White	Q729117	Edmund White	102030733	n79082217	male						judge	PEN America	Diamonstein-Spielvogel Award For The Art Of The Essay	1997	prose	book	15000.0	Fame And Folly: Essays
 2187	Sven Birkerts	Sven	Birkerts	Q2370989	Sven Birkerts	2502462	n86115535	male						judge	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	1997	prose	book	15000.0	Fame And Folly: Essays
 782	Garret Hongo	Garret	Hongo					male		graduate	Univeristy of California, Irvine			judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1998	poetry	book	100000.0	Falling Water
 787	Gary Soto	Gary	Soto	Q5525966	Gary Soto	24617649	n80082328	male		graduate	Univeristy of California, Irvine			judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1998	poetry	book	100000.0	Falling Water
 1147	John Koethe	John	Koethe	Q6243383	John Koethe	119169637	n84038771	male	Princeton University, Harvard University	graduate				winner	Claremont Graduate University	Kingsley Tufts Poetry Award	1998	poetry	book	100000.0	Falling Water
-1100	John (Jack) Miles	John (Jack)	Miles					male	Harvard University	graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1998	poetry	book	100000.0	Falling Water
+1100	John (Jack) Miles	John (Jack)	Miles	Q45963	Jack Miles	24716819	n94067984	male	Harvard University	graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1998	poetry	book	100000.0	Falling Water
 470	Daniel Halpern	Daniel	Halpern	Q55941553	Daniel Halpern	110940158	n50018478	male	Columbia University					judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1998	poetry	book	100000.0	Falling Water
 1983	Robert Polito	Robert	Polito	Q7348947	Robert Polito	114208603	n87923597	male	Harvard University	graduate				judge	National Book Foundation	National Book Award	2014	poetry	book	10000.0	Faithful And Virtuous Night
 2020	Rowan Ricardo Phillips	Rowan Ricardo	Phillips	Q18098755	Rowan Ricardo Phillips	107956881	n2010017339	male	Brown University	graduate				judge	National Book Foundation	National Book Award	2014	poetry	book	10000.0	Faithful And Virtuous Night
@@ -1396,14 +1396,14 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 121	Andre Dubus	Andre	Dubus	Q493118	Andre Dubus	110787061	n79134894	male				3855		judge	National Book Foundation	National Book Award	2005	prose	book	10000.0	Europe Central
 1538	Mark Slouka	Mark	Slouka	Q6769768	Mark Slouka	79501114	n95011562	male	Columbia University	graduate				winner	PEN America	Diamonstein-Spielvogel Award For The Art Of The Essay	2011	prose	book	15000.0	Essays From The Nick Of Time: Reflections And Refutations
 1945	Robert Boyers	Robert	Boyers	Q95399463	Robert Boyers	4951792	n80060886	male		graduate				judge	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	2011	prose	book	15000.0	Essays From The Nick Of Time: Reflections And Refutations
-234	Bernard Knox	Bernard	Knox					male	Harvard University, Yale University	graduate				winner	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	1990	prose	book	15000.0	Essays Ancient And Modern
+234	Bernard Knox	Bernard	Knox	Q822582		100178902	n79040063	male	Harvard University, Yale University	graduate				winner	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	1990	prose	book	15000.0	Essays Ancient And Modern
 501	David Barber	David	Barber					male	Stanford University	graduate			Stegner	judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2015	poetry	book	100000.0	Enchantèe
 1913	Richard Russo	Richard	Russo	Q558430	Richard Russo	49329265	n86089055	male		graduate	University of Arizona			winner	Columbia University	Pulitzer Prize	2002	prose	book	15000.0	Empire Falls
 522	David Kennedy	David	Kennedy	Q1975383	David A. Kennedy	104825600		male	Stanford University, Yale University	graduate				judge	Columbia University	Pulitzer Prize	2002	prose	book	15000.0	Empire Falls
 768	Frederic Tuten	Frederic	Tuten	Q2793520	Frederic Tuten	100238761	n88117173	male		graduate				judge	Columbia University	Pulitzer Prize	2002	prose	book	15000.0	Empire Falls
 1150	John Leonard	John	Leonard	Q6244591	John Leonard	117441217	n79026994	male	Harvard University					judge	Columbia University	Pulitzer Prize	2002	prose	book	15000.0	Empire Falls
 378	Chris Adrian	Chris	Adrian	Q1076930	Chris Adrian	23370866	n00032432	male	Harvard University	graduate	University of Iowa	3711		judge	PEN America	Hemingway Award for Debut Novel	2015	prose	book	10000.0	Elegy On Kinderklavier
-188	Arna Bontemps Hemenway	Arna Bontemps	Hemenway					male		graduate	University of Iowa	2912		winner	PEN America	Hemingway Award for Debut Novel	2015	prose	book	10000.0	Elegy On Kinderklavier
+188	Arna Bontemps Hemenway	Arna Bontemps	Hemenway			305194485	n2013051429	male		graduate	University of Iowa	2912		winner	PEN America	Hemingway Award for Debut Novel	2015	prose	book	10000.0	Elegy On Kinderklavier
 1818	Peter Cameron	Peter	Cameron	Q3376491	Peter Cameron	12330519	n85186638	male						judge	PEN America	Hemingway Award for Debut Novel	2015	prose	book	10000.0	Elegy On Kinderklavier
 961	James Alan McPherson	James Alan	McPherson	Q355793	James Alan McPherson	112082623	n86107938	male	Harvard University	graduate	University of Iowa	592		winner	Columbia University	Pulitzer Prize	1978	prose	book	15000.0	Elbow Room
 755	Frank McConnel	Frank	McConnel					male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1978	prose	book	15000.0	Elbow Room
@@ -1414,17 +1414,17 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1632	Michael Harper	Michael	Harper					male		graduate	University of Iowa	3195		judge	National Book Foundation	National Book Award	1997	poetry	book	10000.0	Effort At Speech: New And Selected Poems
 1393	Li-Young Lee	Li-Young	Lee	Q6538613	Li-Young Lee	66534937	n88615728	male		graduate				judge	National Book Foundation	National Book Award	1997	poetry	book	10000.0	Effort At Speech: New And Selected Poems
 2373	William Meredith	William	Meredith					male	Princeton University					winner	National Book Foundation	National Book Award	1997	poetry	book	10000.0	Effort At Speech: New And Selected Poems
-1110	John Blades	John	Blades					male						judge	National Book Foundation	National Book Award	1985	prose	book	10000.0	Easy In The Islands & White Noise
+1110	John Blades	John	Blades	Q115539470	John U. Blades			male						judge	National Book Foundation	National Book Award	1985	prose	book	10000.0	Easy In The Islands & White Noise
 260	Bob Shacochis	Bob	Shacochis	Q4933931	Bob Shacochis	44315563	n84105588	male						winner	National Book Foundation	National Book Award	1985	prose	book	10000.0	Easy In The Islands
 1037	Jefferson Fletcher	Jefferson	Fletcher					male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1927	prose	book	15000.0	Early Autumn
-1897	Richard Burton	Richard	Burton	Q125057	Richard Francis Burton	29832058	n80057204	male		graduate				judge	Columbia University	Pulitzer Prize	1927	prose	book	15000.0	Early Autumn
+1897	Richard Burton	Richard	Burton	Q84554359	Richard Burton	16015250	n50033772	male		graduate				judge	Columbia University	Pulitzer Prize	1927	prose	book	15000.0	Early Autumn
 1971	Robert Lovett	Robert	Lovett					male	Harvard University					judge	Columbia University	Pulitzer Prize	1927	prose	book	15000.0	Early Autumn
 1424	Louis Bromfield	Louis	Bromfield	Q500042	Louis Bromfield	14766865	n80040365	male	Columbia University					winner	Columbia University	Pulitzer Prize	1927	prose	book	15000.0	Early Autumn
 36	Alan Cheuse	Alan	Cheuse	Q4706366	Alan Cheuse	17273573	n83800485	male		graduate				judge	PEN America	Faulkner Award for Fiction	1989	prose	book	15000.0	Dusk
 753	Frank Conroy	Frank	Conroy	Q1443099	Frank Conroy	66497136	n50032089	male						judge	PEN America	Faulkner Award for Fiction	1989	prose	book	15000.0	Dusk
 987	James Salter	James	Salter	Q1395915	James Salter	85335264	n78094026	male						winner	PEN America	Faulkner Award for Fiction	1989	prose	book	15000.0	Dusk
 1604	Maxwell Geismar	Maxwell	Geismar	Q6796102	Maxwell Geismar	32932096	n50018262	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1943	prose	book	15000.0	Dragon's Teeth
-1115	John Chamberlain	John	Chamberlain	Q6225650	John Chamberlain	39748463	nr90005975	male	Yale University					judge	Columbia University	Pulitzer Prize	1943	prose	book	15000.0	Dragon's Teeth
+1115	John Chamberlain	John	Chamberlain	Q6225652	John Chamberlain	3841537	n83021282	male	Yale University					judge	Columbia University	Pulitzer Prize	1943	prose	book	15000.0	Dragon's Teeth
 1390	Lewis Gannett	Lewis	Gannett	Q62224679	Lewis Gannett	11462821	n90622248	male	Harvard University					judge	Columbia University	Pulitzer Prize	1943	prose	book	15000.0	Dragon's Teeth
 2284	Upton Sinclair	Upton	Sinclair	Q216134	Upton Sinclair	32002923	n79127862	male	Columbia University					winner	Columbia University	Pulitzer Prize	1943	prose	book	15000.0	Dragon's Teeth
 969	James Galvin	James	Galvin	Q6134459	James Galvin	91815764	n80083528	male		graduate	University of Iowa	1000		judge	National Book Foundation	National Book Award	2004	poetry	book	10000.0	Door In The Mountain: New And Collected Poems, 1965-2003
@@ -1453,30 +1453,30 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2139	Stephen Dunn	Stephen	Dunn	Q3973175	Stephen Dunn	114672534	n84077974	male		graduate				winner	Columbia University	Pulitzer Prize	2001	poetry	book	15000.0	Different Hours
 303	C. Michael Curtis	C. Michael	Curtis					male	Cornell University					judge	University of Pittsburg Press	Drue Heinz Literature Prize	2001	prose	book	15000.0	Destination Known
 782	Garret Hongo	Garret	Hongo					male		graduate	Univeristy of California, Irvine			judge	Claremont Graduate University	Kate Tufts Discovery Award 	1996	poetry	book	10000.0	Delirium
-1100	John (Jack) Miles	John (Jack)	Miles					male	Harvard University	graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	1996	poetry	book	10000.0	Delirium
+1100	John (Jack) Miles	John (Jack)	Miles	Q45963	Jack Miles	24716819	n94067984	male	Harvard University	graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	1996	poetry	book	10000.0	Delirium
 1680	Murray Schwartz	Murray	Schwartz					male		graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	1996	poetry	book	10000.0	Delirium
 470	Daniel Halpern	Daniel	Halpern	Q55941553	Daniel Halpern	110940158	n50018478	male	Columbia University					judge	Claremont Graduate University	Kate Tufts Discovery Award 	1996	poetry	book	10000.0	Delirium
 963	James Baker Hall	James Baker	Hall	Q3090478	James Baker Hall	43292531	n85274309	male	Stanford University	graduate			Stegner	judge	Columbia University	Pulitzer Prize	2005	poetry	book	15000.0	Delights And Shadows
 2200	Ted Kooser	Ted	Kooser	Q140196	Ted Kooser	238235132	n78078777	male		graduate				winner	Columbia University	Pulitzer Prize	2005	poetry	book	15000.0	Delights And Shadows
 2341	Wesley McNair	Wesley	McNair	Q7983963	Wesley McNair	35835638	n83187530	male		graduate				judge	Columbia University	Pulitzer Prize	2005	poetry	book	15000.0	Delights And Shadows
 2084	Sergio Troncoso	Sergio	Troncoso	Q7454423	Sergio Troncoso	19004885	n98112999	male	Harvard University, Yale University	graduate				judge	PEN America	Faulkner Award for Fiction	2016	prose	book	15000.0	Delicious Foods
-972	James Hannaham	James	Hannaham	Q53567407	James Hannaham	90541044		male	Yale University					winner	PEN America	Faulkner Award for Fiction	2016	prose	book	15000.0	Delicious Foods
+972	James Hannaham	James	Hannaham	Q53567407	James Hannaham	90541044	no2009091146	male	Yale University					winner	PEN America	Faulkner Award for Fiction	2016	prose	book	15000.0	Delicious Foods
 1907	Richard Lange	Richard	Lange	Q3430958	Richard Lange	11737571	n2006061687	male						winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2008	prose	book	10000.0	Dead Boys: Stories
-1126	John Freeman	John	Freeman	Q6234183	John Freeman	96724864	n2009049319	male						judge	PEN America	Fusion Emerging Writers Prize	2015	prose	book	10000.0	Dead Boys
+1126	John Freeman	John	Freeman	Q4356465	John Freeman	93072292	n91069613	male						judge	PEN America	Fusion Emerging Writers Prize	2015	prose	book	10000.0	Dead Boys
 1058	Jerome Charyn	Jerome	Charyn	Q1687729	Jerome Charyn	98807657	n79064800	male	Columbia University					winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1981	prose	book	10000.0	Darlin' Bill
 344	Charles Baxter	Charles	Baxter	Q5075480	Charles Baxter	103170636	n88040611	male		graduate				judge	University of Pittsburg Press	Drue Heinz Literature Prize	1995	prose	book	15000.0	Dangerous Men
 795	Geoffrey Becker	Geoffrey	Becker	Q5534445	Geoffrey Becker	11554900	n95058178	male						winner	University of Pittsburg Press	Drue Heinz Literature Prize	1995	prose	book	15000.0	Dangerous Men
 1877	Raymond Carver	Raymond	Carver	Q219862	Raymond Carver	88660538	n80113040	male	Stanford University	graduate	University of Iowa	3683	Stegner	judge	University of Pittsburg Press	Drue Heinz Literature Prize	1982	prose	book	15000.0	Dancing For Men
 1997	Robley Wilson	Robley	Wilson	Q7353213	Robley Wilson	7419554	n82018441	male		graduate	University of Iowa	424		winner	University of Pittsburg Press	Drue Heinz Literature Prize	1982	prose	book	15000.0	Dancing For Men
-1483	Manuel Gonzales	Manuel	Gonzales	Q2475822	Manuel González Prada	27088692	n50035324	male	Columbia University	graduate	Columbia University			judge	PEN America	Fusion Emerging Writers Prize	2016	prose	book	10000.0	Crux
+1483	Manuel Gonzales	Manuel	Gonzales	Q3286838	Manuel Gonzales	107463735	no2010031476	male	Columbia University	graduate	Columbia University			judge	PEN America	Fusion Emerging Writers Prize	2016	prose	book	10000.0	Crux
 1177	Johnny Temple	Johnny	Temple					male	Columbia University	graduate				judge	PEN America	Fusion Emerging Writers Prize	2016	prose	book	10000.0	Crux
-1126	John Freeman	John	Freeman	Q6234183	John Freeman	96724864	n2009049319	male						judge	PEN America	Fusion Emerging Writers Prize	2016	prose	book	10000.0	Crux
+1126	John Freeman	John	Freeman	Q4356465	John Freeman	93072292	n91069613	male						judge	PEN America	Fusion Emerging Writers Prize	2016	prose	book	10000.0	Crux
 996	James Wolcott	James	Wolcott	Q6145731	James Wolcott	47689909	n00027340	male						winner	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	2014	prose	book	15000.0	Critical Mass: Four Decades of Essays, Reviews, Hand Grenades, and Hurrahs
 2127	Stanley Fish	Stanley	Fish	Q303680	Stanley Fish	106246231	n50005269	male	University of Pennsylvania, Yale University	graduate				judge	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	2014	prose	book	15000.0	Critical Mass: Four Decades of Essays, Reviews, Hand Grenades, and Hurrahs
 794	Geoff Dyer	Geoff	Dyer	Q1502891	Geoff Dyer	88059533	n87847675	male						judge	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	2014	prose	book	15000.0	Critical Mass: Four Decades of Essays, Reviews, Hand Grenades, and Hurrahs
 364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		winner	National Book Foundation	National Book Award	1983	poetry	book	10000.0	Country Music: Selected Early Poems
 2376	William Phelps	William	Phelps					male	Yale University, Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1919	poetry	book	15000.0	Corn Huskers & Old Road to Paradise
-1897	Richard Burton	Richard	Burton	Q125057	Richard Francis Burton	29832058	n80057204	male		graduate				judge	Columbia University	Pulitzer Prize	1919	poetry	book	15000.0	Corn Huskers & Old Road to Paradise
+1897	Richard Burton	Richard	Burton	Q84554359	Richard Burton	16015250	n50033772	male		graduate				judge	Columbia University	Pulitzer Prize	1919	poetry	book	15000.0	Corn Huskers & Old Road to Paradise
 311	Carl Sandburg	Carl	Sandburg	Q193608	Carl Sandburg	61588662	n79011105	male						winner	Columbia University	Pulitzer Prize	1919	poetry	book	15000.0	Corn Huskers
 183	Archibald Macleish	Archibald	Macleish	Q633354	Archibald MacLeish	85172667	n80015459	male	Yale University	graduate				winner	Columbia University	Pulitzer Prize	1933	poetry	book	15000.0	Conquistador
 2344	Wilbur L. Cross	Wilbur L.	Cross					male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1933	poetry	book	15000.0	Conquistador
@@ -1491,9 +1491,9 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 282	Brian Hooker	Brian	Hooker	Q4964086	Brian Hooker	74119567	n86839418	male	Yale University					judge	Columbia University	Pulitzer Prize	1934	poetry	book	15000.0	Collected Verse
 1105	John Barkham	John	Barkham	Q39079032	John Barkham	238475212	n95065813	male						judge	Columbia University	Pulitzer Prize	1970	prose	book	15000.0	Collected Stories
 1105	John Barkham	John	Barkham	Q39079032	John Barkham	238475212	n95065813	male						judge	Columbia University	Pulitzer Prize	1966	prose	book	15000.0	Collected Stories
-2379	William Rogers	William	Rogers	Q457840	Will Rogers	15573384	n79022274	male	Cornell University	graduate				judge	Columbia University	Pulitzer Prize	1970	prose	book	15000.0	Collected Stories
+2379	William Rogers	William	Rogers					male	Cornell University	graduate				judge	Columbia University	Pulitzer Prize	1970	prose	book	15000.0	Collected Stories
 1604	Maxwell Geismar	Maxwell	Geismar	Q6796102	Maxwell Geismar	32932096	n50018262	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1966	prose	book	15000.0	Collected Stories
-1113	John Brooks	John	Brooks					male	Princeton University					judge	Columbia University	Pulitzer Prize	1970	prose	book	15000.0	Collected Stories
+1113	John Brooks	John	Brooks	Q6223379	John Brooks	62709532	n79063009	male	Princeton University					judge	Columbia University	Pulitzer Prize	1970	prose	book	15000.0	Collected Stories
 857	Harold Bloom	Harold	Bloom	Q345612	Harold Bloom	191378696	n79003258	male	Cornell University, Yale University	graduate				judge	National Book Foundation	National Book Award	1973	poetry	book	10000.0	Collected Poems, 1951-1971
 471	Daniel Hoffman	Daniel	Hoffman	Q5217498	Daniel Hoffman	299139437	n79058587	male	Columbia University	graduate				judge	National Book Foundation	National Book Award	1973	poetry	book	10000.0	Collected Poems, 1951-1971
 6	A. R. Ammons	A. R.	Ammons	Q279077	Archie Randolph Ammons	189145542455696640636	n79081537	male		graduate				winner	National Book Foundation	National Book Award	1973	poetry	book	10000.0	Collected Poems, 1951-1971
@@ -1515,7 +1515,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1430	Louis Untermeyer	Louis	Untermeyer	Q1872015	Louis Untermeyer	39541598	n79054344	male						judge	Columbia University	Pulitzer Prize	1953	poetry	book	15000.0	Collected Poems 1917-1952
 70	Alfred Kreynborg	Alfred	Kreynborg					male						judge	Columbia University	Pulitzer Prize	1955	poetry	book	15000.0	Collected Poems
 70	Alfred Kreynborg	Alfred	Kreynborg					male						judge	Columbia University	Pulitzer Prize	1952	poetry	book	15000.0	Collected Poems
-1739	Norman Pearson	Norman	Pearson	Q16065901	John Norman Pearson	76069026	no2006052284	male	Yale University	graduate				judge	National Book Foundation	National Book Award	1954	poetry	book	10000.0	Collected Poems
+1739	Norman Pearson	Norman	Pearson	Q7052354	Norman Holmes Pearson	27082572	n78090522	male	Yale University	graduate				judge	National Book Foundation	National Book Award	1954	poetry	book	10000.0	Collected Poems
 2344	Wilbur L. Cross	Wilbur L.	Cross					male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1940	poetry	book	15000.0	Collected Poems
 2344	Wilbur L. Cross	Wilbur L.	Cross					male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1931	poetry	book	15000.0	Collected Poems
 2344	Wilbur L. Cross	Wilbur L.	Cross					male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1922	poetry	book	15000.0	Collected Poems
@@ -1588,27 +1588,27 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2305	Vijay Seshadri	Vijay	Seshadri	Q7929205	Vijay Seshadri	1733248	n96038513	male	Columbia University	graduate	Columbia University			judge	Academy of American Poets	Lenore Marshall Poetry Prize	2017	poetry	book	25000.0	Brooklyn Antediluvian
 1626	Michael Chabon	Michael	Chabon	Q313466	Michael Chabon	49255278	n87915233	male		graduate	Univeristy of California, Irvine			judge	University of Pittsburg Press	Drue Heinz Literature Prize	2004	prose	book	15000.0	Bring Your Legs With You
 491	Darrell Spencer	Darrell	Spencer	Q5224718	Darrell Spencer	6605677	n93046537	male		graduate				winner	University of Pittsburg Press	Drue Heinz Literature Prize	2004	prose	book	15000.0	Bring Your Legs With You
-2350	Will Mackin	Will	Mackin					male						winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2019	prose	book	25000.0	Bring Out The Dog
+2350	Will Mackin	Will	Mackin			17150030744810962225	n2017039248	male						winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2019	prose	book	25000.0	Bring Out The Dog
 2344	Wilbur L. Cross	Wilbur L.	Cross					male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1935	poetry	book	15000.0	Bright Ambush
 256	Bliss Perry	Bliss	Perry	Q4926866	Bliss Perry	76448095	n50009730	male		graduate				judge	Columbia University	Pulitzer Prize	1935	poetry	book	15000.0	Bright Ambush
 282	Brian Hooker	Brian	Hooker	Q4964086	Brian Hooker	74119567	n86839418	male	Yale University					judge	Columbia University	Pulitzer Prize	1935	poetry	book	15000.0	Bright Ambush
 342	Chang-Rae Lee	Chang-Rae	Lee	Q533256	Chang-Rae Lee	191038	n94076232	male	Yale University	graduate	University of Oregon			judge	PEN America	Hemingway Award for Debut Novel	2007	prose	book	10000.0	Brief Encounters With Che Guevara
 223	Ben Fountain	Ben	Fountain	Q4885665	Ben Fountain	49546748	n2005069858	male		graduate				winner	PEN America	Hemingway Award for Debut Novel	2007	prose	book	10000.0	Brief Encounters With Che Guevara
 2161	Sue Miller	Sue	Miller	Q3502960	Sue Miller	110431581	n85197689	male						judge	PEN America	Hemingway Award for Debut Novel	2007	prose	book	10000.0	Brief Encounters With Che Guevara
-1828	Peter Prescott	Peter	Prescott					male	Harvard University					judge	Columbia University	Pulitzer Prize	1989	prose	book	15000.0	Breathing Lessons
+1828	Peter Prescott	Peter	Prescott	Q15544954	Peter S. Prescott	22448479	n50028228	male	Harvard University					judge	Columbia University	Pulitzer Prize	1989	prose	book	15000.0	Breathing Lessons
 1193	Jonathan Yardley	Jonathan	Yardley	Q15462185	Jonathan Yardley	69022113	n82269792	male						judge	Columbia University	Pulitzer Prize	1989	prose	book	15000.0	Breathing Lessons
-613	Douglas Hobbie	Douglas	Hobbie					male						winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1992	prose	book	10000.0	Boomfell
-205	Avan Jordan	Avan	Jordan					male		graduate	Warren Wilson College			judge	Academy of American Poets	Lenore Marshall Poetry Prize	2015	poetry	book	25000.0	Book Of Hours
+613	Douglas Hobbie	Douglas	Hobbie	Q107629492		43473371	n91005685	male						winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1992	prose	book	10000.0	Boomfell
+205	Avan Jordan	Avan	Jordan	Q4648474	A. Van Jordan	2121769	no2001077639	male		graduate	Warren Wilson College			judge	Academy of American Poets	Lenore Marshall Poetry Prize	2015	poetry	book	25000.0	Book Of Hours
 1317	Kevin Young	Kevin	Young	Q6397805	Kevin Young	9074736	n94048090	male	Harvard University, Brown University, Stanford University	graduate	Brown University		Stegner	winner	Academy of American Poets	Lenore Marshall Poetry Prize	2015	poetry	book	25000.0	Book Of Hours
 596	Donald Revell	Donald	Revell	Q5295056	Donald Revell	59102325	n82162357	male		graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	2015	poetry	book	25000.0	Book Of Hours
 528	David Long	David	Long					male		graduate	University of Montana			winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1996	prose	book	10000.0	Blue Spruce
-1365	Lawson Inada	Lawson	Inada	Q6504973	Lawson Fusao Inada	77372198	n79058616	male		graduate	University of Oregon			judge	Academy of American Poets	Lenore Marshall Poetry Prize	2002	poetry	book	25000.0	Blue Dusk
+1365	Lawson Inada	Lawson	Inada					male		graduate	University of Oregon			judge	Academy of American Poets	Lenore Marshall Poetry Prize	2002	poetry	book	25000.0	Blue Dusk
 1632	Michael Harper	Michael	Harper					male		graduate	University of Iowa	3195		judge	Academy of American Poets	Lenore Marshall Poetry Prize	2002	poetry	book	25000.0	Blue Dusk
 1969	Robert Kirsch	Robert	Kirsch	Q54859924	Robert Kirsch	40648415	n79056725	male		graduate				judge	National Book Foundation	National Book Award	1978	prose	book	10000.0	Blood Tie
 2292	Vance Bourjaily	Vance	Bourjaily	Q1686332	Vance Bourjaily	97693815	n50000912	male						judge	National Book Foundation	National Book Award	1978	prose	book	10000.0	Blood Tie
 1539	Mark Strand	Mark	Strand	Q928775	Mark Strand	49272680	n79090257	male	Yale University	graduate	University of Iowa	3152		winner	Columbia University	Pulitzer Prize	1999	poetry	book	15000.0	Blizzard Of One
 364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		judge	Columbia University	Pulitzer Prize	1999	poetry	book	15000.0	Blizzard Of One
-545	David St John	David	St John	Q5240011	David St John Thomas	60321473	n50010162	male		graduate	University of Iowa	3483		judge	Columbia University	Pulitzer Prize	1999	poetry	book	15000.0	Blizzard Of One
+545	David St John	David	St John	Q5240013	David St. John	11122111	n79058424	male		graduate	University of Iowa	3483		judge	Columbia University	Pulitzer Prize	1999	poetry	book	15000.0	Blizzard Of One
 1839	Philip Levine	Philip	Levine	Q531273	Philip Levine	110361442	n78093573	male	Stanford University	graduate	University of Iowa	87	Stegner	judge	National Book Foundation	National Book Award	2000	poetry	book	10000.0	Blessing The Boats: New And Selected Poems 1988-2000
 27	Agha Shahid Ali	Agha Shahid	Ali	Q4692327	Agha Shahid Ali	27103182	n85146948	male		graduate	University of Arizona			judge	National Book Foundation	National Book Award	2000	poetry	book	10000.0	Blessing The Boats: New And Selected Poems 1988-2000
 1526	Mark Doty	Mark	Doty	Q1563756	Mark Doty	84141526	n79151575	male		graduate	Goddard College			judge	National Book Foundation	National Book Award	2000	poetry	book	10000.0	Blessing The Boats: New And Selected Poems 1988-2000
@@ -1622,7 +1622,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1839	Philip Levine	Philip	Levine	Q531273	Philip Levine	110361442	n78093573	male	Stanford University	graduate	University of Iowa	87	Stegner	judge	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2011	prose	book	10000.0	Bitter In The Mouth
 782	Garret Hongo	Garret	Hongo					male		graduate	Univeristy of California, Irvine			judge	Claremont Graduate University	Kate Tufts Discovery Award 	1999	poetry	book	10000.0	Bite Every Sorrow
 787	Gary Soto	Gary	Soto	Q5525966	Gary Soto	24617649	n80082328	male		graduate	Univeristy of California, Irvine			judge	Claremont Graduate University	Kate Tufts Discovery Award 	1999	poetry	book	10000.0	Bite Every Sorrow
-1100	John (Jack) Miles	John (Jack)	Miles					male	Harvard University	graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	1999	poetry	book	10000.0	Bite Every Sorrow
+1100	John (Jack) Miles	John (Jack)	Miles	Q45963	Jack Miles	24716819	n94067984	male	Harvard University	graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	1999	poetry	book	10000.0	Bite Every Sorrow
 470	Daniel Halpern	Daniel	Halpern	Q55941553	Daniel Halpern	110940158	n50018478	male	Columbia University					judge	Claremont Graduate University	Kate Tufts Discovery Award 	1999	poetry	book	10000.0	Bite Every Sorrow
 1449	Luis Alberto Urrea	Luis Alberto	Urrea	Q1876315	Luis Alberto Urrea	94241372	n92083371	male		graduate	University of Colorado			judge	Center for Fiction	First Novel Prize	2012	prose	book	15000.0	Billy Lynn's Long Halftime Walk
 223	Ben Fountain	Ben	Fountain	Q4885665	Ben Fountain	49546748	n2005069858	male		graduate				winner	Center for Fiction	First Novel Prize	2012	prose	book	15000.0	Billy Lynn's Long Halftime Walk
@@ -1654,7 +1654,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		judge	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2013	prose	book	10000.0	Battleborn
 1423	Louis Begley	Louis	Begley	Q314843	Louis Begley	84023825	n91018358	male	Harvard University	graduate				judge	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2013	prose	book	10000.0	Battleborn
 1862	Rafael Campo	Rafael	Campo	Q7282063	Rafael Campo	92108981	n94016553	male		graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	1999	poetry	book	25000.0	Bathwater Wine
-726	Evan Connell	Evan	Connell					male	Stanford University	graduate			Stegner	judge	National Book Foundation	National Book Award	1973	prose	book	10000.0	Augustus & Chimera
+726	Evan Connell	Evan	Connell	Q2693491	Evan S. Connell	97745717	n50000126	male	Stanford University	graduate			Stegner	judge	National Book Foundation	National Book Award	1973	prose	book	10000.0	Augustus & Chimera
 2363	William Gass	William	Gass	Q304874	William H. Gass	108798167	n79096948	male	Cornell University	graduate				judge	National Book Foundation	National Book Award	1973	prose	book	10000.0	Augustus & Chimera
 1386	Leslie Fielder	Leslie	Fielder					male		graduate				judge	National Book Foundation	National Book Award	1973	prose	book	10000.0	Augustus & Chimera
 1193	Jonathan Yardley	Jonathan	Yardley	Q15462185	Jonathan Yardley	69022113	n82269792	male						judge	National Book Foundation	National Book Award	1973	prose	book	10000.0	Augustus & Chimera
@@ -1665,7 +1665,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1430	Louis Untermeyer	Louis	Untermeyer	Q1872015	Louis Untermeyer	39541598	n79054344	male						judge	Columbia University	Pulitzer Prize	1964	poetry	book	15000.0	At The End Of The Open Road
 1839	Philip Levine	Philip	Levine	Q531273	Philip Levine	110361442	n78093573	male	Stanford University	graduate	University of Iowa	87	Stegner	winner	National Book Foundation	National Book Award	1980	poetry	book	10000.0	Ashes: Poems New And Old
 1722	Nick Arvin	Nick	Arvin	Q7026727	Nick Arvin	36275373	n2002042145	male	Stanford University	graduate	University of Iowa	2490		winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2006	prose	book	10000.0	Articles Of War
-1897	Richard Burton	Richard	Burton	Q125057	Richard Francis Burton	29832058	n80057204	male		graduate				judge	Columbia University	Pulitzer Prize	1926	prose	book	15000.0	Arrowsmith
+1897	Richard Burton	Richard	Burton	Q84554359	Richard Burton	16015250	n50033772	male		graduate				judge	Columbia University	Pulitzer Prize	1926	prose	book	15000.0	Arrowsmith
 2111	Sinclair Lewis	Sinclair	Lewis  	Q123469	Sinclair Lewis	39380311	n79023149	male	Yale University					winner	Columbia University	Pulitzer Prize	1926	prose	book	15000.0	Arrowsmith
 1971	Robert Lovett	Robert	Lovett					male	Harvard University					judge	Columbia University	Pulitzer Prize	1926	prose	book	15000.0	Arrowsmith
 645	Edwin Lefevre	Edwin	Lefevre	Q2556046	Edwin Lefèvre	79111477	n50037985	male						judge	Columbia University	Pulitzer Prize	1926	prose	book	15000.0	Arrowsmith
@@ -1679,13 +1679,13 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2320	Wallace Stegner	Wallace	Stegner	Q203460	Wallace Stegner	110195864	n79021163	male		graduate				winner	Columbia University	Pulitzer Prize	1972	prose	book	15000.0	Angel Of Repose
 1468	Mackinlay Kantor	Mackinlay	Kantor	Q1226282	MacKinlay Kantor	46839470	n79140979	male						winner	Columbia University	Pulitzer Prize	1956	prose	book	15000.0	Andersonville
 314	Carlos Baker	Carlos	Baker	Q5041809	Carlos Baker	107027003	n50020883	male	Dartmouth College, Harvard University, Princeton University	graduate				judge	Columbia University	Pulitzer Prize	1956	prose	book	15000.0	Andersonville
-745	Francis Brown	Francis	Brown					male	Dartmouth College, Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1956	prose	book	15000.0	Andersonville
-2009	Ron Childress	Ron	Childress					male						winner	PEN America	Bellwether Prize for Socially Engaged Fiction	2014	prose	book	25000.0	And West Is West
+745	Francis Brown	Francis	Brown	Q60150800	Francis Brown	57461376	n50039648	male	Dartmouth College, Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1956	prose	book	15000.0	Andersonville
+2009	Ron Childress	Ron	Childress	Q32945231		315984804	n2015030853	male						winner	PEN America	Bellwether Prize for Socially Engaged Fiction	2014	prose	book	25000.0	And West Is West
 1477	Major Jackson	Major	Jackson	Q6738100	Major Jackson	162945253	n2001041364	male		graduate	University of Oregon			judge	Academy of American Poets	Lenore Marshall Poetry Prize	2019	poetry	book	25000.0	Anagnorisis
 547	David Wojahn	David	Wojahn	Q5241252	David Wojahn	68953589	n81104795	male		graduate	University of Arizona			judge	Academy of American Poets	Lenore Marshall Poetry Prize	2019	poetry	book	25000.0	Anagnorisis
 1332	Kyle Dargan	Kyle	Dargan	Q55713617	Kyle Dargan	1858488	n2004035194	male		graduate	Indiana University			winner	Academy of American Poets	Lenore Marshall Poetry Prize	2019	poetry	book	25000.0	Anagnorisis
 32	Akhil Sharma	Akhil	Sharma	Q4700740	Akhil Sharma	74034664	n00020898	male	Princeton University, Stanford University, Harvard University	graduate			Stegner	winner	PEN America	Hemingway Award for Debut Novel	2001	prose	book	10000.0	An Obedient Father
-2260	Tom Cole	Tom	Cole					male	Harvard University	graduate				winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1966	prose	book	10000.0	An End To Chivalry
+2260	Tom Cole	Tom	Cole	Q26785088	Tom Cole	75505357	n92034111	male	Harvard University	graduate				winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1966	prose	book	10000.0	An End To Chivalry
 637	Edward Hirsch	Edward	Hirsch	Q5343460	Edward Hirsch	46805662	n80153675	male	University of Pennsylvania	graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	1992	poetry	book	25000.0	An Atlas Of The Difficult World
 2222	Thomas Lux	Thomas	Lux	Q7791985	Thomas Lux	4959112	n79063797	male						judge	Academy of American Poets	Lenore Marshall Poetry Prize	1992	poetry	book	25000.0	An Atlas Of The Difficult World
 1111	John Blair	John	Blair	Q3181069	John Blair	30727597	n84204485	male		graduate				winner	University of Pittsburg Press	Drue Heinz Literature Prize	2002	prose	book	15000.0	American Standard
@@ -1707,14 +1707,14 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 517	David Haynes	David	Haynes	Q66686137	David Haynes	79463327	n94045167	male		graduate				judge	Columbia University	Pulitzer Prize	2015	prose	book	15000.0	All The Light We Cannot See
 1604	Maxwell Geismar	Maxwell	Geismar	Q6796102	Maxwell Geismar	32932096	n50018262	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1947	prose	book	15000.0	All The King's Men
 1980	Robert Penn Warren	Robert Penn	Warren	Q312720	Robert Penn Warren	61553765	n78091524	male		graduate				winner	Columbia University	Pulitzer Prize	1947	prose	book	15000.0	All The King's Men
-1115	John Chamberlain	John	Chamberlain	Q6225650	John Chamberlain	39748463	nr90005975	male	Yale University					judge	Columbia University	Pulitzer Prize	1947	prose	book	15000.0	All The King's Men
+1115	John Chamberlain	John	Chamberlain	Q6225652	John Chamberlain	3841537	n83021282	male	Yale University					judge	Columbia University	Pulitzer Prize	1947	prose	book	15000.0	All The King's Men
 1752	Orville Prescott	Orville	Prescott	Q7105248	Orville Prescott	237553275	n50028227	male						judge	Columbia University	Pulitzer Prize	1947	prose	book	15000.0	All The King's Men
 941	J. D. McClatchy	J. D.	McClatchy	Q915445	J. D. McClatchy	98044618	n77011314	male	Yale University	graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	2009	poetry	book	25000.0	All Of It Singing: New And Selected Poems
-985	James Richardson	James	Richardson					male	Princeton University	graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	2009	poetry	book	25000.0	All Of It Singing: New And Selected Poems
-46	Alan Williamson	Alan	Williamson					male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1997	poetry	book	15000.0	Alive Together: New And Selected Poems
+985	James Richardson	James	Richardson	Q6142078	James Richardson	109846678	n84014323	male	Princeton University	graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	2009	poetry	book	25000.0	All Of It Singing: New And Selected Poems
+46	Alan Williamson	Alan	Williamson	Q104493595	Alan Williamson			male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1997	poetry	book	15000.0	Alive Together: New And Selected Poems
 1037	Jefferson Fletcher	Jefferson	Fletcher					male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1922	prose	book	15000.0	Alice Adams
 264	Booth Tarkington	Booth	Tarkington	Q893138	Booth Tarkington	54154708	n79078124	male	Princeton University					winner	Columbia University	Pulitzer Prize	1922	prose	book	15000.0	Alice Adams
-2049	Samuel Crothers	Samuel	Crothers					male						judge	Columbia University	Pulitzer Prize	1922	prose	book	15000.0	Alice Adams
+2049	Samuel Crothers	Samuel	Crothers	Q7412138	Samuel McChord Crothers	66604792	n50057777	male						judge	Columbia University	Pulitzer Prize	1922	prose	book	15000.0	Alice Adams
 2160	Stuart Sherman	Stuart	Sherman	Q7627085	Stuart Sherman	67408433	n50023078	male						judge	Columbia University	Pulitzer Prize	1922	prose	book	15000.0	Alice Adams
 781	Garrard Conley	Garrard	Conley	Q57204353	Garrard Conley	316549535	n2015040269	male		graduate	Brooklyn College			judge	PEN America	Diamonstein-Spielvogel Award For The Art Of The Essay	2019	prose	book	15000.0	Against Memoir: Complaints, Confessions & Criticisms
 1794	Paul Reyes	Paul	Reyes					male						judge	PEN America	Diamonstein-Spielvogel Award For The Art Of The Essay	2019	prose	book	15000.0	Against Memoir: Complaints, Confessions & Criticisms
@@ -1736,15 +1736,15 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 961	James Alan McPherson	James Alan	McPherson	Q355793	James Alan McPherson	112082623	n86107938	male	Harvard University	graduate	University of Iowa	592		judge	Columbia University	Pulitzer Prize	1992	prose	book	15000.0	A Thousand Acres
 755	Frank McConnel	Frank	McConnel					male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1992	prose	book	15000.0	A Thousand Acres
 755	Frank McConnel	Frank	McConnel					male	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1987	prose	book	15000.0	A Summons To Memphis
-1828	Peter Prescott	Peter	Prescott					male	Harvard University					judge	Columbia University	Pulitzer Prize	1987	prose	book	15000.0	A Summons To Memphis
-1831	Peter Taylor	Peter	Taylor					male						winner	Columbia University	Pulitzer Prize	1987	prose	book	15000.0	A Summons To Memphis
+1828	Peter Prescott	Peter	Prescott	Q15544954	Peter S. Prescott	22448479	n50028228	male	Harvard University					judge	Columbia University	Pulitzer Prize	1987	prose	book	15000.0	A Summons To Memphis
+1831	Peter Taylor	Peter	Taylor	Q979076	Peter Matthew Hillsman Taylor	108819469	n50008415	male						winner	Columbia University	Pulitzer Prize	1987	prose	book	15000.0	A Summons To Memphis
 1146	John Knowles	John	Knowles	Q983113	John Knowles	109382098	n50042387	male	Yale University					winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1961	prose	book	10000.0	A Separate Peace
 465	Daniel Aaron	Daniel	Aaron					male	Harvard University	graduate				judge	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	1995	prose	book	15000.0	A Sense Of Place, A Sense Of Time 
 1112	John Brinckerhoff Jackson	John Brinckerhoff	Jackson	Q6104703	J. B. Jackson	100295076	n83185732	male	Harvard University					winner	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	1995	prose	book	15000.0	A Sense Of Place, A Sense Of Time 
 2248	Timothy Donnelly	Timothy	Donnelly	Q7807159	Timothy Donnelly	6752424	n2002041614	male	Columbia University	graduate	Columbia University			judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2020	poetry	book	100000.0	A Sand Book
 1451	Luis Rodriguez	Luis	Rodriguez					male						judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2020	poetry	book	100000.0	A Sand Book
 551	Davidl Ulin	Davidl	Ulin					male	University of Pennsylvania					judge	PEN America	Hemingway Award for Debut Novel	2020	prose	book	10000.0	A Prayer For Travelers
-2085	Serio De La Pava	Serio	De La Pava					male		graduate				winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2013	prose	book	25000.0	A Naked Singularity
+2085	Sergio De La Pava	Sergio	De La Pava	Q16210893	Sergio de la Pava	172980519	no2011116075	male		graduate				winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2013	prose	book	25000.0	A Naked Singularity
 595	Donald Ray Pollock	Donald Ray	Pollock	Q1240267	Donald Ray Pollock	53606234	n2007069632	male						judge	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2013	prose	book	25000.0	A Naked Singularity
 2262	Tom Drury	Tom	Drury	Q7815662	Tom Drury	92004401	n93107058	male						judge	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2013	prose	book	25000.0	A Naked Singularity
 1635	Michael Lowenthal	Michael	Lowenthal	Q6832333	Michael Lowenthal	21375455	n94098045	male	Dartmouth College					judge	PEN America	Hemingway Award for Debut Novel	2010	prose	book	10000.0	A Long Long Time Ago And Essentially True
@@ -1774,13 +1774,13 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1479	Malcolm Cowley	Malcolm	Cowley	Q1458319	Malcolm Cowley	91308069	n79081720	male	Harvard University					judge	National Book Foundation	National Book Award	1955	prose	book	10000.0	A Fable
 2361	William Faulkner	William	Faulkner	Q38392	William Faulkner	39376770	n79003304	male						winner	National Book Foundation	National Book Award	1955	prose	book	10000.0	A Fable
 2361	William Faulkner	William	Faulkner	Q38392	William Faulkner	39376770	n79003304	male						winner	Columbia University	Pulitzer Prize	1963	prose	book	15000.0	A Fable
-2388	Williammelvin Kelley	Williammelvin	Kelley					male	Harvard University					winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1963	prose	book	10000.0	A Different Drummer
+2388	William Melvin Kelley	William Melvin	Kelley	Q8015558	William Melvin Kelley	49244542	n50048130	male	Harvard University					winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1963	prose	book	10000.0	A Different Drummer
 960	James Agee	James	Agee	Q352963	James Agee	46756190	n79039544	male	Harvard University					winner	Columbia University	Pulitzer Prize	1958	prose	book	15000.0	A Death In The Family
 1959	Robert Gorham Davis	Robert Gorham	Davis	Q47681708	Robert Gorham Davis	55390915	n50035626	male	Harvard University					judge	Columbia University	Pulitzer Prize	1958	prose	book	15000.0	A Death In The Family
 1141	John Hutch	John	Hutch					male						judge	Columbia University	Pulitzer Prize	1958	prose	book	15000.0	A Death In The Family
-935	Issac Bashevis Singer	Issac Bashevis	Singer					male						winner	National Book Foundation	National Book Award	1974	prose	book	10000.0	A Crown Of Feathers And Other Stories
+935	Isaac Bashevis Singer	Issac Bashevis	Singer	Q75612	Isaac Bashevis Singer	95207392	n79066617	male						winner	National Book Foundation	National Book Award	1974	prose	book	10000.0	A Crown Of Feathers And Other Stories
 1145	John Kennedy Toole	John Kennedy	Toole	Q313739	John Kennedy Toole	71398405	n79102341	male	Columbia University	graduate				winner	Columbia University	Pulitzer Prize	1981	prose	book	15000.0	A Confederacy Of Dunces
-1828	Peter Prescott	Peter	Prescott					male	Harvard University					judge	Columbia University	Pulitzer Prize	1981	prose	book	15000.0	A Confederacy Of Dunces
+1828	Peter Prescott	Peter	Prescott	Q15544954	Peter S. Prescott	22448479	n50028228	male	Harvard University					judge	Columbia University	Pulitzer Prize	1981	prose	book	15000.0	A Confederacy Of Dunces
 1193	Jonathan Yardley	Jonathan	Yardley	Q15462185	Jonathan Yardley	69022113	n82269792	male						judge	Columbia University	Pulitzer Prize	1981	prose	book	15000.0	A Confederacy Of Dunces
 1218	Joseph Skibell	Joseph	Skibell	Q6287025	Joseph Skibell	92881582	n97041368	male		graduate	University of Texas, Austin			winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1998	prose	book	10000.0	A Blessing On The Moon
 7	A. R. Gurney	A. R.	Gurney	Q328627	A. R. Gurney	84234746	n50020353	male		graduate	Yale University			judge	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2009	prose	book	10000.0	A Better Angel
@@ -1791,7 +1791,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 631	Edmund White	Edmund	White	Q729117	Edmund White	102030733	n79082217	male						judge	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2009	prose	book	10000.0	A Better Angel
 1136	John Hersey	John	Hersey	Q535812	John Hersey	105148984	n79054652	male	Yale University	graduate				winner	Columbia University	Pulitzer Prize	1945	prose	book	15000.0	A Bell For Adano
 1604	Maxwell Geismar	Maxwell	Geismar	Q6796102	Maxwell Geismar	32932096	n50018262	male	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1945	prose	book	15000.0	A Bell For Adano
-1115	John Chamberlain	John	Chamberlain	Q6225650	John Chamberlain	39748463	nr90005975	male	Yale University					judge	Columbia University	Pulitzer Prize	1945	prose	book	15000.0	A Bell For Adano
+1115	John Chamberlain	John	Chamberlain	Q6225652	John Chamberlain	3841537	n83021282	male	Yale University					judge	Columbia University	Pulitzer Prize	1945	prose	book	15000.0	A Bell For Adano
 1752	Orville Prescott	Orville	Prescott	Q7105248	Orville Prescott	237553275	n50028227	male						judge	Columbia University	Pulitzer Prize	1945	prose	book	15000.0	A Bell For Adano
 2128	Stanley Kunitz	Stanley	Kunitz	Q1974852	Stanley Kunitz	109638294	n79007720	male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1965	poetry	book	15000.0	77 Dream Songs
 1108	John Berryman	John	Berryman	Q522192	John Berryman	71421263	n79142591	male	Columbia University					winner	Columbia University	Pulitzer Prize	1965	poetry	book	15000.0	77 Dream Songs
@@ -1800,24 +1800,24 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2305	Vijay Seshadri	Vijay	Seshadri	Q7929205	Vijay Seshadri	1733248	n96038513	male	Columbia University	graduate	Columbia University			winner	Columbia University	Pulitzer Prize	2014	poetry	book	15000.0	3 Sections
 16	Adam Kirsch	Adam	Kirsch	Q4679350	Adam Kirsch	119488947	n2002024448	male	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	2014	poetry	book	15000.0	3 Sections
 887	Herb Liebowitz	Herb	Liebowitz					male						judge	Claremont Graduate University	Kate Tufts Discovery Award 	1994	poetry	book	10000.0	1-800-Hot-Ribs
-1100	John (Jack) Miles	John (Jack)	Miles					male	Harvard University	graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	1994	poetry	book	10000.0	1-800-Hot-Ribs
+1100	John (Jack) Miles	John (Jack)	Miles	Q45963	Jack Miles	24716819	n94067984	male	Harvard University	graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	1994	poetry	book	10000.0	1-800-Hot-Ribs
 1680	Murray Schwartz	Murray	Schwartz					male		graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	1994	poetry	book	10000.0	1-800-Hot-Ribs
 1822	Peter Davison	Peter	Davison	Q7173576	Peter Davison	64018487	n80061240	male	Harvard University					judge	Claremont Graduate University	Kate Tufts Discovery Award 	1994	poetry	book	10000.0	1-800-Hot-Ribs
 464	Danez Smith	Danez	Smith	Q24572302	Danez Smith	388144647693193740161	no2015133518	male		graduate	University of Michigan			winner	Claremont Graduate University	Kate Tufts Discovery Award 	2016	poetry	book	10000.0	[Insert] Boy
 283	Brian Kim Stefans	Brian Kim	Stefans	Q4964351	Brian Kim Stefans	265064436	n2002029377	male	Brown University	graduate	Brown University			judge	Claremont Graduate University	Kate Tufts Discovery Award 	2016	poetry	book	10000.0	[Insert] Boy
 587	Don Share	Don	Share	Q5293504	Don Share	55730698	n88642863	male	Brown University	graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	2016	poetry	book	10000.0	[Insert] Boy
-20	Adrian Castro	Adrian	Castro					male						judge	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2014	no genre	career	50000.0	
-20	Adrian Castro	Adrian	Castro					male						winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2012	no genre	career	50000.0	
+20	Adrian Castro	Adrian	Castro	Q120768294	Adrian Castro	38657991	n97052898	male						judge	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2014	no genre	career	50000.0	
+20	Adrian Castro	Adrian	Castro	Q120768294	Adrian Castro	38657991	n97052898	male						winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2012	no genre	career	50000.0	
 198	Atsuro Riley	Atsuro	Riley	Q4817791	Atsuro Riley	90572443	no2009096568	male						winner	Lannan Foundation	Lannan Fellowship	2011	poetry	career	50000.0	
 198	Atsuro Riley	Atsuro	Riley	Q4817791	Atsuro Riley	90572443	no2009096568	male						winner	Whiting Foundation	Whiting Award	2012	no genre	career	50000.0	
-469	Daniel Hall	Daniel	Hall					male						winner	Whiting Foundation	Whiting Award	1998	no genre	career	50000.0	
+469	Daniel Hall	Daniel	Hall	Q5217410	Daniel Hall	102408421	n88241977	male						winner	Whiting Foundation	Whiting Award	1998	no genre	career	50000.0	
 549	David Wood	David	Wood	Q3019012	David Wood	102074796	n81132086	male						judge	New Literary Project (University of California, Berkeley and Lafayette Library)	Joyce Carol Oates Literary Prize/Simpson Family	2017	prose	career	50000.0	
-758	Frank Rooney	Frank	Rooney	Q110940860	Frank Rooney	162934088		male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1956	no genre	career	10000.0	
+758	Frank Rooney	Frank	Rooney	Q110940860	Frank Rooney	162934088	n88668999	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1956	no genre	career	10000.0	
 775	Freeman House	Freeman	House					male						winner	American Academy of Arts and Letters	Harold D. Vursell Memorial Award	2002	prose	career	20000.0	
 797	Geoffrey O'Brien	Geoffrey	O'Brien	Q5534796	Geoffrey O'Brien	28384219	n80147819	male						judge	Yale University	Bollingen Prize for Poetry	2013	poetry	career	10000.0	
 797	Geoffrey O'Brien	Geoffrey	O'Brien	Q5534796	Geoffrey O'Brien	28384219	n80147819	male						winner	Whiting Foundation	Whiting Award	1988	no genre	career	50000.0	
 804	George Green	George	Green					male						winner	American Academy of Arts and Letters	Arts and Letters Awards	2014	no genre	career	10000.0	
-813	Gilbert Hernandez	Gilbert	Hernandez					male						winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2009	no genre	career	50000.0	
+813	Gilbert Hernandez	Gilbert	Hernandez	Q949202	Gilbert Hernandez	5052971	n88616356	male						winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2009	no genre	career	50000.0	
 912	Hugo Ignotus	Hugo	Ignotus	Q216148	Ignotus	4134722	n92120805	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1944	no genre	career	10000.0	
 934	Israel Horovitz	Israel	Horovitz	Q356397	Israel Horovitz	7402620	n80038305	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1972	no genre	career	10000.0	
 952	Jacob Shores-Arguello	Jacob	Shores-Arguello					male						winner	Lannan Foundation	Lannan Fellowship	2018	poetry	career	50000.0	
@@ -1826,17 +1826,17 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1109	John Biguenet	John	Biguenet	Q6221880	John Biguenet	66506428	n77014808	male						judge	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2010	no genre	career	50000.0	
 1162	John O'Hara	John	O'Hara	Q548345	John O'Hara	12429524	n79060653	male						winner	American Academy of Arts and Letters	Award of Merit Medal in the Novel	1964	prose	career	25000.0	
 1201	José Rivera	José	Rivera	Q1709607	José Rivera	120204049	n00030443	male						winner	Whiting Foundation	Whiting Award	1992	no genre	career	50000.0	
-1221	Joseph Wittlin	Joseph	Wittlin					male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1943	no genre	career	10000.0	
+1221	Józef Wittlin	Józef	Wittlin	Q364741	Józef Wittlin	17243203	n81118552	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1943	no genre	career	10000.0	
 1314	Kevin Barry	Kevin	Barry	Q6395795	Kevin Barry	48680401	n2007053033	male						winner	Lannan Foundation	Lannan Award	2016	prose	career	150000.0	
-1450	Luis Alfaro	Luis	Alfaro					male						winner	Ford Foundation	Art of Change	2017	no genre	career	50000.0	
-1451	Luis Rodriguez	Luis	Rodriguez					male						winner	Lannan Foundation	Lannan Award	1992	poetry	career	150000.0	
-1485	Marc Bittner	Marc	Bittner					male						winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2002	poetry	career	25800.0	
+1450	Luis Alfaro	Luis	Alfaro	Q6700296	Luis Alfaro	73428182	no94007445	male						winner	Ford Foundation	Art of Change	2017	no genre	career	50000.0	
+1451	Luis J. Rodriguez	Luis	Rodriguez	Q3840366	Luis J. Rodriguez	36984636	n91048289	male						winner	Lannan Foundation	Lannan Award	1992	poetry	career	150000.0	
+1485	Mark Bittner	Mark	Bittner	Q6766746	Mark Bittner	55984004	n2003033669	male						winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2002	poetry	career	25800.0	
 1633	Michael Haskell	Michael	Haskell					male						winner	Whiting Foundation	Whiting Award	1999	no genre	career	50000.0	
 1684	Nadeem Aslam	Nadeem	Aslam	Q1963189	Nadeem Aslam	32247620	nr94014964	male						winner	Lannan Foundation	Lannan Fellowship	2005	prose	career	50000.0	
-1747	Oliver Gogarty	Oliver	Gogarty					male						winner	Academy of American Poets	Academy of American Poets Fellowship	1954	poetry	career	25000.0	
+1747	Oliver Gogarty	Oliver	Gogarty	Q1388518	Oliver St John Gogarty	32004745	n81040729	male						winner	Academy of American Poets	Academy of American Poets Fellowship	1954	poetry	career	25000.0	
 1782	Paul Clemens	Paul	Clemens	Q20880942	Paul Clemens	75718311	n2005009662	male						winner	Whiting Foundation	Whiting Award	2011	no genre	career	50000.0	
 1815	Peter Bagge	Peter	Bagge	Q1340737	Peter Bagge	44591469	n95103628	male						winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2014	no genre	career	50000.0	
-1888	Reinaldo Povod	Reinaldo	Povod					male						winner	Whiting Foundation	Whiting Award	1987	no genre	career	50000.0	
+1888	Reinaldo Povod	Reinaldo	Povod	Q7310256	Reinaldo Povod	4007705	n87942563	male						winner	Whiting Foundation	Whiting Award	1987	no genre	career	50000.0	
 1995	Robin Robertson	Robin	Robertson	Q7352748	Robin Robertson	118144828	nr97024217	male						winner	American Academy of Arts and Letters	E. M. Forster Award	2004	no genre	career	10000.0	
 2030	Russ Rymer	Russ	Rymer	Q7381228	Russ Rymer			male						winner	Whiting Foundation	Whiting Award	1995	no genre	career	50000.0	
 2245	Tim Pears	Tim	Pears	Q1420273	Tim Pears	79154587	nr94019203	male						winner	Lannan Foundation	Lannan Award	1996	prose	career	150000.0	
@@ -1844,7 +1844,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2322	Walter Abish	Walter	Abish	Q213806	Walter Abish	96215590	n80102276	male						winner	American Academy of Arts and Letters	Award of Merit Medal in the Novel	1991	prose	career	25000.0	
 2322	Walter Abish	Walter	Abish	Q213806	Walter Abish	96215590	n80102276	male						winner	MacArthur Foundation	MacArthur Fellowship	1987	no genre	career	500000.0	
 2364	William Gay	William	Gay	Q3568651	William Gay	39769248	n99046248	male						winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2007	no genre	career	50000.0	
-708	Erik Ehn	Erik	Ehn					male	Yale University	graduate	Yale University			winner	Whiting Foundation	Whiting Award	1997	no genre	career	50000.0	
+708	Erik Ehn	Erik	Ehn	Q5388563	Erik Ehn	29407289	nr93025623	male	Yale University	graduate	Yale University			winner	Whiting Foundation	Whiting Award	1997	no genre	career	50000.0	
 1384	Leslie Epstein	Leslie	Epstein	Q6530788	Leslie Epstein	91399648	n79079404	male	Yale University	graduate	Yale University			winner	American Academy of Arts and Letters	Arts and Letters Awards	1978	no genre	career	10000.0	
 2227	Thomas McGuane	Thomas	McGuane	Q2265116	Thomas McGuane	79030467	n79084435	male	Stanford University	graduate	Yale University		Stegner	judge	American Academy of Arts and Letters	Arthur Rense Prize	2017	poetry	career	20000.0	
 2227	Thomas McGuane	Thomas	McGuane	Q2265116	Thomas McGuane	79030467	n79084435	male	Stanford University	graduate	Yale University		Stegner	judge	American Academy of Arts and Letters	Arts and Letters Awards	2017	no genre	career	10000.0	
@@ -1853,7 +1853,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2227	Thomas McGuane	Thomas	McGuane	Q2265116	Thomas McGuane	79030467	n79084435	male	Stanford University	graduate	Yale University		Stegner	judge	American Academy of Arts and Letters	Harold D. Vursell Memorial Award	2017	prose	career	20000.0	
 2227	Thomas McGuane	Thomas	McGuane	Q2265116	Thomas McGuane	79030467	n79084435	male	Stanford University	graduate	Yale University		Stegner	judge	American Academy of Arts and Letters	John Updike Award	2017	no genre	career	20000.0	
 2227	Thomas McGuane	Thomas	McGuane	Q2265116	Thomas McGuane	79030467	n79084435	male	Stanford University	graduate	Yale University		Stegner	judge	American Academy of Arts and Letters	Metcalf Awards	2017	no genre	career	10000.0	
-395	Christopher Durang	Christopher	Durang					male	Harvard University	graduate	Yale University			winner	American Academy of Arts and Letters	Arts and Letters Awards	2002	no genre	career	10000.0	
+395	Christopher Durang	Christopher	Durang	Q328590	Christopher Durang	79044746	n78067537	male	Harvard University	graduate	Yale University			winner	American Academy of Arts and Letters	Arts and Letters Awards	2002	no genre	career	10000.0	
 1902	Richard Foreman	Richard	Foreman					male	Brown University	graduate	Yale University			winner	American Academy of Arts and Letters	Arts and Letters Awards	1992	no genre	career	10000.0	
 7	A. R. Gurney	A. R.	Gurney	Q328627	A. R. Gurney	84234746	n50020353	male		graduate	Yale University			judge	American Academy of Arts and Letters	Arts and Letters Awards	2013	no genre	career	10000.0	
 7	A. R. Gurney	A. R.	Gurney	Q328627	A. R. Gurney	84234746	n50020353	male		graduate	Yale University			judge	American Academy of Arts and Letters	Arts and Letters Awards	2009	no genre	career	10000.0	
@@ -1865,8 +1865,8 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 7	A. R. Gurney	A. R.	Gurney	Q328627	A. R. Gurney	84234746	n50020353	male		graduate	Yale University			judge	American Academy of Arts and Letters	John Updike Award	2013	no genre	career	20000.0	
 7	A. R. Gurney	A. R.	Gurney	Q328627	A. R. Gurney	84234746	n50020353	male		graduate	Yale University			judge	American Academy of Arts and Letters	Metcalf Awards	2013	no genre	career	10000.0	
 7	A. R. Gurney	A. R.	Gurney	Q328627	A. R. Gurney	84234746	n50020353	male		graduate	Yale University			judge	American Academy of Arts and Letters	Metcalf Awards	2009	no genre	career	10000.0	
-727	Evan Smith	Evan	Smith	Q21064288	Evan Smith			male		graduate	Yale University			winner	Whiting Foundation	Whiting Award	2002	no genre	career	50000.0	
-1056	Jeremy O. Harris	Jeremy O.	Harris					male		graduate	Yale University			winner	American Academy of Arts and Letters	Arts and Letters Awards	2020	no genre	career	10000.0	
+727	Evan Smith	Evan	Smith	Q5415548	Evan Smith	36328509	n2005064322	male		graduate	Yale University			winner	Whiting Foundation	Whiting Award	2002	no genre	career	50000.0	
+1056	Jeremy O. Harris	Jeremy O.	Harris	Q112042530	Jeremy O'Harris			male		graduate	Yale University			winner	American Academy of Arts and Letters	Arts and Letters Awards	2020	no genre	career	10000.0	
 1131	John Guare	John	Guare	Q320556	John Guare	71506879	n80065728	male		graduate	Yale University			judge	American Academy of Arts and Letters	Arthur Rense Prize	2020	poetry	career	20000.0	
 1131	John Guare	John	Guare	Q320556	John Guare	71506879	n80065728	male		graduate	Yale University			judge	American Academy of Arts and Letters	Arthur Rense Prize	2017	poetry	career	20000.0	
 1131	John Guare	John	Guare	Q320556	John Guare	71506879	n80065728	male		graduate	Yale University			judge	American Academy of Arts and Letters	Arts and Letters Awards	2020	no genre	career	10000.0	
@@ -1922,14 +1922,14 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 455	Damien Wilkins	Damien	Wilkins	Q5212534	Damien Wilkins	93519265	nr92020607	male		graduate	Washington University			winner	Whiting Foundation	Whiting Award	1992	no genre	career	50000.0	
 1454	Luther Hughes	Luther	Hughes					male		graduate	Washington University			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2020	poetry	career	25800.0	
 1629	Michael Dahlie	Michael	Dahlie	Q6829680	Michael Dahlie	63404567	n2004097865	male		graduate	Washington University			winner	Whiting Foundation	Whiting Award	2010	no genre	career	50000.0	
-1846	Philip Williams	Philip	Williams					male		graduate	Washington University			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2013	poetry	career	25800.0	
-1846	Philip Williams	Philip	Williams					male		graduate	Washington University			winner	Whiting Foundation	Whiting Award	2017	no genre	career	50000.0	
-1931	Rickey Laurentiis	Rickey	Laurentiis					male		graduate	Washington University			winner	Lannan Foundation	Lannan Fellowship	2017	poetry	career	50000.0	
-1931	Rickey Laurentiis	Rickey	Laurentiis					male		graduate	Washington University			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2012	poetry	career	25800.0	
-1931	Rickey Laurentiis	Rickey	Laurentiis					male		graduate	Washington University			winner	Whiting Foundation	Whiting Award	2018	no genre	career	50000.0	
-205	Avan Jordan	Avan	Jordan					male		graduate	Warren Wilson College			winner	Lannan Foundation	Lannan Award	2015	poetry	career	150000.0	
-205	Avan Jordan	Avan	Jordan					male		graduate	Warren Wilson College			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2008	no genre	career	50000.0	
-205	Avan Jordan	Avan	Jordan					male		graduate	Warren Wilson College			winner	Whiting Foundation	Whiting Award	2004	no genre	career	50000.0	
+1846	Philip Williams	Philip	Williams	Q60607911	Philip Williams			male		graduate	Washington University			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2013	poetry	career	25800.0	
+1846	Philip Williams	Philip	Williams	Q60607911	Philip Williams			male		graduate	Washington University			winner	Whiting Foundation	Whiting Award	2017	no genre	career	50000.0	
+1931	Rickey Laurentiis	Rickey	Laurentiis	Q55713358	Rickey Laurentiis	315603201	no2015050391	male		graduate	Washington University			winner	Lannan Foundation	Lannan Fellowship	2017	poetry	career	50000.0	
+1931	Rickey Laurentiis	Rickey	Laurentiis	Q55713358	Rickey Laurentiis	315603201	no2015050391	male		graduate	Washington University			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2012	poetry	career	25800.0	
+1931	Rickey Laurentiis	Rickey	Laurentiis	Q55713358	Rickey Laurentiis	315603201	no2015050391	male		graduate	Washington University			winner	Whiting Foundation	Whiting Award	2018	no genre	career	50000.0	
+205	Avan Jordan	Avan	Jordan	Q4648474	A. Van Jordan	2121769	no2001077639	male		graduate	Warren Wilson College			winner	Lannan Foundation	Lannan Award	2015	poetry	career	150000.0	
+205	Avan Jordan	Avan	Jordan	Q4648474	A. Van Jordan	2121769	no2001077639	male		graduate	Warren Wilson College			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2008	no genre	career	50000.0	
+205	Avan Jordan	Avan	Jordan	Q4648474	A. Van Jordan	2121769	no2001077639	male		graduate	Warren Wilson College			winner	Whiting Foundation	Whiting Award	2004	no genre	career	50000.0	
 280	Brian Blanchfield	Brian	Blanchfield	Q21964335	Brian Blanchfield	9220578	n2003041229	male		graduate	Warren Wilson College			winner	Whiting Foundation	Whiting Award	2016	no genre	career	50000.0	
 431	Cornelius Eady	Cornelius	Eady	Q5171355	Cornelius Eady	77765819	n85266803	male		graduate	Warren Wilson College			winner	Folger Shakespeare Library	O. B. Hardison Poetry Prize	2003	poetry	career	10000.0	
 894	Hieu Minh Nguyen	Hieu Minh	Nguyen	Q22073630	Hieu Minh Nguyen			male		graduate	Warren Wilson College			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2018	poetry	career	25800.0	
@@ -1940,7 +1940,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1525	Mark Cox	Mark	Cox	Q6767184	Mark Cox	68030436	n88219057	male		graduate	Vermont College of Fine Arts 			winner	Whiting Foundation	Whiting Award	1987	no genre	career	50000.0	
 620	Ed Ochester	Ed	Ochester	Q5335241	Ed Ochester	57297	n82267849	male	Cornell University, Harvard University	graduate	University of Wisconsin			judge	Library of Congress	Rebekah Johnson Bobbitt National Prize For Poetry	2004	poetry	career	10000.0	
 476	Daniel Orozco	Daniel	Orozco	Q5218346	Daniel Orozco	144492984	n2010061669	male	Stanford University	graduate	University of Washington		Stegner	winner	Whiting Foundation	Whiting Award	2011	no genre	career	50000.0	
-352	Charles Harper Webb	Charles Harper	Webb					male		graduate	University of Washington			winner	Whiting Foundation	Whiting Award	1998	no genre	career	50000.0	
+352	Charles Harper Webb	Charles Harper	Webb	Q5078789	Charles Harper Webb	36077392	n90663599	male		graduate	University of Washington			winner	Whiting Foundation	Whiting Award	1998	no genre	career	50000.0	
 1588	Matthew Nienow	Matthew	Nienow					male		graduate	University of Washington			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2013	poetry	career	25800.0	
 33	Al Filreis	Al	Filreis	Q4703826	Al Filreis	97812951	n86065150	male		graduate	University of Virginia			judge	Yale University	Bollingen Prize for Poetry	2015	poetry	career	10000.0	
 639	Edward P. Jones	Edward P.	Jones	Q942627	Edward P. Jones	87444362	n91094103	male		graduate	University of Virginia			winner	American Academy of Arts and Letters	Arts and Letters Awards	2005	no genre	career	10000.0	
@@ -1981,8 +1981,8 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1477	Major Jackson	Major	Jackson	Q6738100	Major Jackson	162945253	n2001041364	male		graduate	University of Oregon			judge	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2010	no genre	career	50000.0	
 1477	Major Jackson	Major	Jackson	Q6738100	Major Jackson	162945253	n2001041364	male		graduate	University of Oregon			judge	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2009	no genre	career	50000.0	
 1477	Major Jackson	Major	Jackson	Q6738100	Major Jackson	162945253	n2001041364	male		graduate	University of Oregon			winner	Whiting Foundation	Whiting Award	2003	no genre	career	50000.0	
-1975	Robert Morgan	Robert	Morgan	Q21453628	Robert Morgan	70207494	n79081567	male		graduate	University of North Carolina, Greensboro			winner	American Academy of Arts and Letters	Arts and Letters Awards	2007	no genre	career	10000.0	
-2068	Sarah Lindsay	Sarah	Lindsay					male		graduate	University of North Carolina, Greensboro			winner	Lannan Foundation	Lannan Fellowship	2009	poetry	career	50000.0	
+1975	Robert Morgan	Robert	Morgan	Q7347798	Robert Morgan	113817347	n80060847	male		graduate	University of North Carolina, Greensboro			winner	American Academy of Arts and Letters	Arts and Letters Awards	2007	no genre	career	10000.0	
+2068	Sarah Lindsay	Sarah	Lindsay	Q7422537	Sarah Lindsay	40810989	n85142047	male		graduate	University of North Carolina, Greensboro			winner	Lannan Foundation	Lannan Fellowship	2009	poetry	career	50000.0	
 1057	Jericho Brown	Jericho	Brown	Q15440076	Jericho Brown	317141438	no2009022322	male		graduate	University of New Orleans			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2020	no genre	career	50000.0	
 1057	Jericho Brown	Jericho	Brown	Q15440076	Jericho Brown	317141438	no2009022322	male		graduate	University of New Orleans			winner	Whiting Foundation	Whiting Award	2009	no genre	career	50000.0	
 458	Dan Josefson	Dan	Josefson					male		graduate	University of Nevada			winner	Whiting Foundation	Whiting Award	2015	no genre	career	50000.0	
@@ -1990,14 +1990,14 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1707	Nathan Bartel	Nathan	Bartel					male		graduate	University of Montana			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2004	poetry	career	25800.0	
 1988	Robert Wrigley	Robert	Wrigley	Q7351272	Robert Wrigley	52952040	n78090918	male		graduate	University of Montana			judge	Poets & Writers	Jackson Poetry Prize	2020	poetry	career	75000.0	
 413	Claude Wilkinson	Claude	Wilkinson	Q5129076	Claude Wilkinson	28845892	n98044335	male		graduate	University of Mississippi			winner	Whiting Foundation	Whiting Award	2000	no genre	career	50000.0	
-2024	Roy Guzman	Roy	Guzman					male		graduate	University of Minnesota			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2017	poetry	career	25800.0	
+2024	Roy Guzman	Roy	Guzman	Q57584605	Roy G. Guzmán			male		graduate	University of Minnesota			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2017	poetry	career	25800.0	
 1062	Jess Row	Jess	Row	Q6186013	Jess Row	56001723	n2004036108	male	Yale University	graduate	University of Michigan			winner	Whiting Foundation	Whiting Award	2003	no genre	career	50000.0	
 1625	Michael Byers	Michael	Byers	Q6828979	Michael Byers	92961816	n97115944	male	Stanford University	graduate	University of Michigan		Stegner	winner	Whiting Foundation	Whiting Award	1998	no genre	career	50000.0	
 1873	Rattawut Lapcharoensap	Rattawut	Lapcharoensap	Q21064593	Rattawut Lapcharoensap	119708555	n2004044002	male	Cornell University	graduate	University of Michigan			winner	Whiting Foundation	Whiting Award	2010	no genre	career	50000.0	
 464	Danez Smith	Danez	Smith	Q24572302	Danez Smith	388144647693193740161	no2015133518	male		graduate	University of Michigan			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2014	poetry	career	25800.0	
 600	Donovan Hohn	Donovan	Hohn					male		graduate	University of Michigan			winner	Whiting Foundation	Whiting Award	2008	no genre	career	50000.0	
 1623	Michael Awkward	Michael	Awkward	Q110092621	Michael Awkward	69055375	n88002194	male		graduate	University of Michigan			judge	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2016	no genre	career	50000.0	
-1706	Nate Marshall	Nate	Marshall	Q112136131	Nate Marshall	2611145857120522922027		male		graduate	University of Michigan			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2015	poetry	career	25800.0	
+1706	Nate Marshall	Nate	Marshall	Q112136131	Nate Marshall	2611145857120522922027	no2016022152	male		graduate	University of Michigan			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2015	poetry	career	25800.0	
 1774	Patrick O'Keefe	Patrick	O'Keefe					male		graduate	University of Michigan			winner	Whiting Foundation	Whiting Award	2006	no genre	career	50000.0	
 276	Brendan Galvin	Brendan	Galvin	Q4960892	Brendan Galvin	36946719	n79105983	male		graduate	University of Massachusetts, Amherst			winner	Folger Shakespeare Library	O. B. Hardison Poetry Prize	1991	poetry	career	10000.0	
 1885	Reginald Dwayne Betts	Reginald Dwayne	Betts					male		graduate	University of Maryland			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2012	poetry	career	25800.0	
@@ -2136,15 +2136,15 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 348	Charles D'Ambrosio	Charles	D'Ambrosio	Q2628164	Charles D'Ambrosio	61709569	n94091495	male		graduate	University of Iowa	2063		winner	Lannan Foundation	Lannan Fellowship	2008	prose	career	50000.0	
 348	Charles D'Ambrosio	Charles	D'Ambrosio	Q2628164	Charles D'Ambrosio	61709569	n94091495	male		graduate	University of Iowa	2063		winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2007	no genre	career	50000.0	
 348	Charles D'Ambrosio	Charles	D'Ambrosio	Q2628164	Charles D'Ambrosio	61709569	n94091495	male		graduate	University of Iowa	2063		winner	Whiting Foundation	Whiting Award	2006	no genre	career	50000.0	
-364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		judge	Academy of American Poets	Academy of American Poets Fellowship	2002	poetry	career	25000.0	
-364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		judge	Academy of American Poets	Academy of American Poets Fellowship	2001	poetry	career	25000.0	
-364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		judge	Academy of American Poets	Academy of American Poets Fellowship	2000	poetry	career	25000.0	
+364	Charles Wright	Charles	Wright	Q19788098	Charles Wright	114558743	n85050261	male		graduate	University of Iowa	175		judge	Academy of American Poets	Academy of American Poets Fellowship	2002	poetry	career	25000.0	
+364	Charles Wright	Charles	Wright	Q19788098	Charles Wright	114558743	n85050261	male		graduate	University of Iowa	175		judge	Academy of American Poets	Academy of American Poets Fellowship	2001	poetry	career	25000.0	
+364	Charles Wright	Charles	Wright	Q19788098	Charles Wright	114558743	n85050261	male		graduate	University of Iowa	175		judge	Academy of American Poets	Academy of American Poets Fellowship	2000	poetry	career	25000.0	
 364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		judge	American Academy of Arts and Letters	Arthur Rense Prize	2014	poetry	career	20000.0	
 364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		judge	American Academy of Arts and Letters	Arts and Letters Awards	2015	no genre	career	10000.0	
 364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		judge	American Academy of Arts and Letters	Arts and Letters Awards	2014	no genre	career	10000.0	
 364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		judge	American Academy of Arts and Letters	Arts and Letters Awards	2013	no genre	career	10000.0	
-364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		winner	American Academy of Arts and Letters	Arts and Letters Awards	1977	no genre	career	10000.0	
-364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		winner	American Academy of Arts and Letters	Award of Merit Medal in Poetry	1992	poetry	career	25000.0	
+364	Charles Wright	Charles	Wright	Q19788098	Charles Wright	114558743	n85050261	male		graduate	University of Iowa	175		winner	American Academy of Arts and Letters	Arts and Letters Awards	1977	no genre	career	10000.0	
+364	Charles Wright	Charles	Wright	Q19788098	Charles Wright	114558743	n85050261	male		graduate	University of Iowa	175		winner	American Academy of Arts and Letters	Award of Merit Medal in Poetry	1992	poetry	career	25000.0	
 364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		judge	American Academy of Arts and Letters	Award of Merit Medal in the Novel	2015	prose	career	25000.0	
 364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		judge	American Academy of Arts and Letters	Benjamin H. Danks Award	2014	no genre	career	20000.0	
 364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		winner	Yale University	Bollingen Prize for Poetry	2013	poetry	career	10000.0	
@@ -2161,11 +2161,11 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		judge	American Academy of Arts and Letters	Morton Dauwen Zabel Award	2014	poetry	career	10000.0	
 364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		winner	Library of Congress	Poet Laureate	2015	poetry	career	35000.0	
 364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		winner	Library of Congress	Poet Laureate	2014	poetry	career	35000.0	
-364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		winner	Library of Congress	Rebekah Johnson Bobbitt National Prize For Poetry	2008	poetry	career	10000.0	
-364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		winner	Poetry Foundation	Ruth Lilly Poetry Prize	1993	poetry	career	100000.0	
-364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		judge	Academy of American Poets	Wallace Stevens Award	2002	poetry	career	100000.0	
-364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		judge	Academy of American Poets	Wallace Stevens Award	2001	poetry	career	100000.0	
-364	Charles Wright	Charles	Wright	Q2960465	Charles Wright	110426741	n78095427	male		graduate	University of Iowa	175		judge	Academy of American Poets	Wallace Stevens Award	2000	poetry	career	100000.0	
+364	Charles Wright	Charles	Wright	Q19788098	Charles Wright	114558743	n85050261	male		graduate	University of Iowa	175		winner	Library of Congress	Rebekah Johnson Bobbitt National Prize For Poetry	2008	poetry	career	10000.0	
+364	Charles Wright	Charles	Wright	Q19788098	Charles Wright	114558743	n85050261	male		graduate	University of Iowa	175		winner	Poetry Foundation	Ruth Lilly Poetry Prize	1993	poetry	career	100000.0	
+364	Charles Wright	Charles	Wright	Q19788098	Charles Wright	114558743	n85050261	male		graduate	University of Iowa	175		judge	Academy of American Poets	Wallace Stevens Award	2002	poetry	career	100000.0	
+364	Charles Wright	Charles	Wright	Q19788098	Charles Wright	114558743	n85050261	male		graduate	University of Iowa	175		judge	Academy of American Poets	Wallace Stevens Award	2001	poetry	career	100000.0	
+364	Charles Wright	Charles	Wright	Q19788098	Charles Wright	114558743	n85050261	male		graduate	University of Iowa	175		judge	Academy of American Poets	Wallace Stevens Award	2000	poetry	career	100000.0	
 383	Chris Offutt	Chris	Offutt	Q5107639	Chris Offutt	79145036	n92008720	male		graduate	University of Iowa	2023		winner	Lannan Foundation	Lannan Fellowship	2003	prose	career	50000.0	
 383	Chris Offutt	Chris	Offutt	Q5107639	Chris Offutt	79145036	n92008720	male		graduate	University of Iowa	2023		winner	Whiting Foundation	Whiting Award	1996	no genre	career	50000.0	
 412	Clark Blaise	Clark	Blaise	Q1095680	Clark Blaise	7439147	n50008515	male		graduate	University of Iowa	177		winner	American Academy of Arts and Letters	Arts and Letters Awards	2003	no genre	career	10000.0	
@@ -2173,24 +2173,24 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 448	D. A. Powell	D. A.	Powell	Q5203478	D. A. Powell	28821341	n97105916	male		graduate	University of Iowa	2263		judge	Poets & Writers	Jackson Poetry Prize	2019	poetry	career	75000.0	
 448	D. A. Powell	D. A.	Powell	Q5203478	D. A. Powell	28821341	n97105916	male		graduate	University of Iowa	2263		winner	American Academy of Arts and Letters	John Updike Award	2019	no genre	career	20000.0	
 478	Daniel Woodrell	Daniel	Woodrell	Q1163210	Daniel Woodrell	69055692	n85146288	male		graduate	University of Iowa	1495		winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2014	no genre	career	50000.0	
-497	David Adjmi	David	Adjmi					male		graduate	University of Iowa	missing		winner	Whiting Foundation	Whiting Award	2010	no genre	career	50000.0	
-545	David St John	David	St John	Q5240011	David St John Thomas	60321473	n50010162	male		graduate	University of Iowa	3483		judge	Academy of American Poets	Academy of American Poets Fellowship	2020	poetry	career	25000.0	
-545	David St John	David	St John	Q5240011	David St John Thomas	60321473	n50010162	male		graduate	University of Iowa	3483		judge	Academy of American Poets	Academy of American Poets Fellowship	2019	poetry	career	25000.0	
-545	David St John	David	St John	Q5240011	David St John Thomas	60321473	n50010162	male		graduate	University of Iowa	3483		judge	Academy of American Poets	Academy of American Poets Fellowship	2018	poetry	career	25000.0	
-545	David St John	David	St John	Q5240011	David St John Thomas	60321473	n50010162	male		graduate	University of Iowa	3483		judge	Academy of American Poets	Academy of American Poets Fellowship	2017	poetry	career	25000.0	
-545	David St John	David	St John	Q5240011	David St John Thomas	60321473	n50010162	male		graduate	University of Iowa	3483		winner	American Academy of Arts and Letters	Arts and Letters Awards	2000	no genre	career	10000.0	
-545	David St John	David	St John	Q5240011	David St John Thomas	60321473	n50010162	male		graduate	University of Iowa	3483		judge	Poets & Writers	Jackson Poetry Prize	2014	poetry	career	75000.0	
-545	David St John	David	St John	Q5240011	David St John Thomas	60321473	n50010162	male		graduate	University of Iowa	3483		winner	Folger Shakespeare Library	O. B. Hardison Poetry Prize	2001	poetry	career	10000.0	
-545	David St John	David	St John	Q5240011	David St John Thomas	60321473	n50010162	male		graduate	University of Iowa	3483		judge	Academy of American Poets	Wallace Stevens Award	2020	poetry	career	100000.0	
-545	David St John	David	St John	Q5240011	David St John Thomas	60321473	n50010162	male		graduate	University of Iowa	3483		judge	Academy of American Poets	Wallace Stevens Award	2019	poetry	career	100000.0	
-545	David St John	David	St John	Q5240011	David St John Thomas	60321473	n50010162	male		graduate	University of Iowa	3483		judge	Academy of American Poets	Wallace Stevens Award	2018	poetry	career	100000.0	
-545	David St John	David	St John	Q5240011	David St John Thomas	60321473	n50010162	male		graduate	University of Iowa	3483		judge	Academy of American Poets	Wallace Stevens Award	2017	poetry	career	100000.0	
+497	David Adjmi	David	Adjmi	Q5230620	David Adjmi	165358322	no2011015081	male		graduate	University of Iowa	missing		winner	Whiting Foundation	Whiting Award	2010	no genre	career	50000.0	
+545	David St John	David	St John	Q5240013	David St. John	11122111	n79058424	male		graduate	University of Iowa	3483		judge	Academy of American Poets	Academy of American Poets Fellowship	2020	poetry	career	25000.0	
+545	David St John	David	St John	Q5240013	David St. John	11122111	n79058424	male		graduate	University of Iowa	3483		judge	Academy of American Poets	Academy of American Poets Fellowship	2019	poetry	career	25000.0	
+545	David St John	David	St John	Q5240013	David St. John	11122111	n79058424	male		graduate	University of Iowa	3483		judge	Academy of American Poets	Academy of American Poets Fellowship	2018	poetry	career	25000.0	
+545	David St John	David	St John	Q5240013	David St. John	11122111	n79058424	male		graduate	University of Iowa	3483		judge	Academy of American Poets	Academy of American Poets Fellowship	2017	poetry	career	25000.0	
+545	David St John	David	St John	Q5240013	David St. John	11122111	n79058424	male		graduate	University of Iowa	3483		winner	American Academy of Arts and Letters	Arts and Letters Awards	2000	no genre	career	10000.0	
+545	David St John	David	St John	Q5240013	David St. John	11122111	n79058424	male		graduate	University of Iowa	3483		judge	Poets & Writers	Jackson Poetry Prize	2014	poetry	career	75000.0	
+545	David St John	David	St John	Q5240013	David St. John	11122111	n79058424	male		graduate	University of Iowa	3483		winner	Folger Shakespeare Library	O. B. Hardison Poetry Prize	2001	poetry	career	10000.0	
+545	David St John	David	St John	Q5240013	David St. John	11122111	n79058424	male		graduate	University of Iowa	3483		judge	Academy of American Poets	Wallace Stevens Award	2020	poetry	career	100000.0	
+545	David St John	David	St John	Q5240013	David St. John	11122111	n79058424	male		graduate	University of Iowa	3483		judge	Academy of American Poets	Wallace Stevens Award	2019	poetry	career	100000.0	
+545	David St John	David	St John	Q5240013	David St. John	11122111	n79058424	male		graduate	University of Iowa	3483		judge	Academy of American Poets	Wallace Stevens Award	2018	poetry	career	100000.0	
+545	David St John	David	St John	Q5240013	David St. John	11122111	n79058424	male		graduate	University of Iowa	3483		judge	Academy of American Poets	Wallace Stevens Award	2017	poetry	career	100000.0	
 548	David Wong Louie	David	Wong Louie	Q5241270	David Wong Louie	93957051	n90720357	male		graduate	University of Iowa	1308		winner	Lannan Foundation	Lannan Fellowship	2001	prose	career	50000.0	
 569	Denis Johnson	Denis	Johnson	Q340016	Denis Johnson	51707360	n81147004	male		graduate	University of Iowa	786		winner	American Academy of Arts and Letters	Arts and Letters Awards	1993	no genre	career	10000.0	
 569	Denis Johnson	Denis	Johnson	Q340016	Denis Johnson	51707360	n81147004	male		graduate	University of Iowa	786		winner	American Academy of Arts and Letters	Award of Merit Medal in the Novel	2009	prose	career	25000.0	
 569	Denis Johnson	Denis	Johnson	Q340016	Denis Johnson	51707360	n81147004	male		graduate	University of Iowa	786		winner	Lannan Foundation	Lannan Award	1993	prose	career	150000.0	
 569	Denis Johnson	Denis	Johnson	Q340016	Denis Johnson	51707360	n81147004	male		graduate	University of Iowa	786		winner	Whiting Foundation	Whiting Award	1986	no genre	career	50000.0	
-634	Eduardo Corral	Eduardo	Corral					male		graduate	University of Iowa	2495		winner	Whiting Foundation	Whiting Award	2011	no genre	career	50000.0	
+634	Eduardo Corral	Eduardo	Corral	Q5340546	Eduardo C. Corral			male		graduate	University of Iowa	2495		winner	Whiting Foundation	Whiting Award	2011	no genre	career	50000.0	
 969	James Galvin	James	Galvin	Q6134459	James Galvin	91815764	n80083528	male		graduate	University of Iowa	1000		winner	Lannan Foundation	Lannan Fellowship	2002	poetry	career	50000.0	
 980	James McConkey	James	McConkey	Q66124234	James McConkey	217833560	n83050690	male		graduate	University of Iowa	3196		winner	American Academy of Arts and Letters	Arts and Letters Awards	1979	no genre	career	10000.0	
 994	James Tate	James	Tate	Q531155	James Tate	57136	n78094025	male		graduate	University of Iowa	345		judge	Academy of American Poets	Academy of American Poets Fellowship	2007	poetry	career	25000.0	
@@ -2216,14 +2216,14 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1487	Marcos Villatoro	Marcos	Villatoro	Q6757941	Marcos Villatoro	79556484	n95077977	male		graduate	University of Iowa	missing		judge	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2007	no genre	career	50000.0	
 1624	Michael Burkard	Michael	Burkard	Q6828936	Michael Burkard	75124085	n79040892	male		graduate	University of Iowa	700		winner	Whiting Foundation	Whiting Award	1988	no genre	career	50000.0	
 1632	Michael Harper	Michael	Harper					male		graduate	University of Iowa	3195		winner	American Academy of Arts and Letters	Arts and Letters Awards	1972	no genre	career	10000.0	
-1641	Michael Ryan	Michael	Ryan					male		graduate	University of Iowa	missing		winner	Whiting Foundation	Whiting Award	1987	no genre	career	50000.0	
+1641	Michael Ryan	Michael	Ryan	Q6834055	Michael Ryan	7620757	n80090635	male		graduate	University of Iowa	missing		winner	Whiting Foundation	Whiting Award	1987	no genre	career	50000.0	
 1708	Nathan Englander	Nathan	Englander	Q1655990	Nathan Englander	97520065	n98075379	male		graduate	University of Iowa	2233		judge	PEN America	Saul Bellow Award For Achievement In American Fiction	2010	prose	career	25000.0	
 1826	Peter Orner	Peter	Orner	Q7176232	Peter Orner	76543980	n2001022989	male		graduate	University of Iowa	2367		winner	Lannan Foundation	Lannan Fellowship	2006	prose	career	50000.0	
 1844	Philip Schultz	Philip	Schultz	Q7184353	Philip Schultz	22469870	n78035943	male		graduate	University of Iowa	609		winner	American Academy of Arts and Letters	Arts and Letters Awards	1979	no genre	career	10000.0	
 1895	Richard Bausch	Richard	Bausch	Q3430510	Richard Bausch	263596254	n80019827	male		graduate	University of Iowa	833		winner	American Academy of Arts and Letters	Arts and Letters Awards	1993	no genre	career	10000.0	
 2044	Salvatore Scibona	Salvatore	Scibona	Q7406693	Salvatore Scibona	107610836	no2008072140	male		graduate	University of Iowa	2425		judge	PEN America	W. G. Sebald Award For Fiction Writer In Mid-Career	2011	prose	career	10000.0	
 2044	Salvatore Scibona	Salvatore	Scibona	Q7406693	Salvatore Scibona	107610836	no2008072140	male		graduate	University of Iowa	2425		winner	Whiting Foundation	Whiting Award	2009	no genre	career	50000.0	
-2052	Samuel Hunter	Samuel	Hunter					male		graduate	University of Iowa	missing		winner	Whiting Foundation	Whiting Award	2012	no genre	career	50000.0	
+2052	Samuel Hunter	Samuel	Hunter	Q3471150	Samuel Hunter			male		graduate	University of Iowa	missing		winner	Whiting Foundation	Whiting Award	2012	no genre	career	50000.0	
 2087	Shane McCrae	Shane	McCrae	Q7488159	Shane McCrae	122179516	n2010038282	male		graduate	University of Iowa	4054		winner	Lannan Foundation	Lannan Fellowship	2017	poetry	career	50000.0	
 2087	Shane McCrae	Shane	McCrae	Q7488159	Shane McCrae	122179516	n2010038282	male		graduate	University of Iowa	4054		winner	Whiting Foundation	Whiting Award	2011	no genre	career	50000.0	
 2146	Stephen Wright	Stephen	Wright	Q7610892	Stephen Wright	84682174	n83166118	male		graduate	University of Iowa	903		winner	Lannan Foundation	Lannan Award	1994	prose	career	150000.0	
@@ -2238,7 +2238,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2311	Vu Tran	Vu	Tran	Q7943283	Vu Tran	315084236	n2015012639	male		graduate	University of Iowa	2586		winner	Whiting Foundation	Whiting Award	2009	no genre	career	50000.0	
 2312	W. D. Snodgrass	W. D.	Snodgrass	Q1334959	W. D. Snodgrass	117357452	n50014773	male		graduate	University of Iowa	62		winner	Academy of American Poets	Academy of American Poets Fellowship	1972	poetry	career	25000.0	
 2312	W. D. Snodgrass	W. D.	Snodgrass	Q1334959	W. D. Snodgrass	117357452	n50014773	male		graduate	University of Iowa	62		winner	American Academy of Arts and Letters	Arts and Letters Awards	1960	no genre	career	10000.0	
-2313	W. David Hancock	W. David	Hancock					male		graduate	University of Iowa	missing		winner	Whiting Foundation	Whiting Award	1998	no genre	career	50000.0	
+2313	W. David Hancock	W. David	Hancock	Q7945444	W. David Hancock			male		graduate	University of Iowa	missing		winner	Whiting Foundation	Whiting Award	1998	no genre	career	50000.0	
 994	James Tate	James	Tate	Q531155	James Tate	57136	n78094025	male			University of Iowa	345		winner	American Academy of Arts and Letters	Arts and Letters Awards	1974	no genre	career	10000.0	
 1041	Jeffrey Renard Allen	Jeffrey Renard	Allen	Q6176228	Jeffrey Renard Allen	166804294	n97061177	male		graduate	University of Illinois			winner	Whiting Foundation	Whiting Award	2002	no genre	career	50000.0	
 702	Eric Ekstrand	Eric	Ekstrand					male		graduate	University of Houston			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2009	poetry	career	25800.0	
@@ -2308,10 +2308,10 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2403	Yusef Komunyakaa	Yusef	Komunyakaa	Q2601996	Yusef Komunyakaa	32006129	n82203462	male		graduate	Univeristy of California, Irvine			judge	Academy of American Poets	Wallace Stevens Award	1999	poetry	career	100000.0	
 1647	Michaelr Jackson	Michaelr	Jackson					male		graduate	Tisch School of the Arts			winner	Whiting Foundation	Whiting Award	2019	no genre	career	50000.0	
 2075	Scott Blackwood	Scott	Blackwood	Q21005094	Scott Blackwood			male		graduate	Texas State University			winner	Whiting Foundation	Whiting Award	2011	no genre	career	50000.0	
-974	James Ijames	James	Ijames					male		graduate	Temple University			winner	Whiting Foundation	Whiting Award	2017	no genre	career	50000.0	
+974	James Ijames	James	Ijames	Q48785088	James Ijames			male		graduate	Temple University			winner	Whiting Foundation	Whiting Award	2017	no genre	career	50000.0	
 456	Dan Chaon	Dan	Chaon	Q3013030	Dan Chaon	22359144	n95061138	male		graduate	Syracuse University			winner	American Academy of Arts and Letters	Arts and Letters Awards	2006	no genre	career	10000.0	
 1978	Robert P. Marzec	Robert P.	Marzec					male		graduate	SUNY Binghamton			judge	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2016	no genre	career	50000.0	
-762	Frank Walker	Frank	Walker					male		graduate	Spalding University			winner	Lannan Foundation	Lannan Fellowship	2005	poetry	career	50000.0	
+762	Frank Walker	Frank	Walker	Q5490193	Frank Walker	68774342	nr89002805	male		graduate	Spalding University			winner	Lannan Foundation	Lannan Fellowship	2005	poetry	career	50000.0	
 228	Benjamin Percy	Benjamin	Percy	Q4889110	Benjamin Percy	73608189	no2006061119	male	Brown University	graduate	Southern Illinois State University			winner	Whiting Foundation	Whiting Award	2008	no genre	career	50000.0	
 21	Adrian Matejka	Adrian	Matejka	Q4685208	Adrian Matejka	14142797	n2003040844	male		graduate	Southern Illinois State University			winner	Lannan Foundation	Lannan Fellowship	2014	poetry	career	50000.0	
 21	Adrian Matejka	Adrian	Matejka	Q4685208	Adrian Matejka	14142797	n2003040844	male		graduate	Southern Illinois State University			judge	Library of Congress	Rebekah Johnson Bobbitt National Prize For Poetry	2020	poetry	career	10000.0	
@@ -2319,14 +2319,14 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1788	Paul Guest	Paul	Guest	Q7151033	Paul Guest	2156875	no2003058317	male		graduate	Southern Illinois State University			winner	Whiting Foundation	Whiting Award	2007	no genre	career	50000.0	
 1644	Michael Wasson	Michael	Wasson					male		graduate	Oregon State University			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2019	poetry	career	25800.0	
 1581	Matt Collinsworth	Matt	Collinsworth					male		graduate	Ohio State University			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	1995	poetry	career	15000.0	
-2347	Will Arbery	Will	Arbery					male		graduate	Northwestern University			winner	Whiting Foundation	Whiting Award	2020	no genre	career	50000.0	
+2347	Will Arbery	Will	Arbery	Q114739852	Will Arbery	310146461602527731896	no2016068942	male		graduate	Northwestern University			winner	Whiting Foundation	Whiting Award	2020	no genre	career	50000.0	
 2283	Tyree Daye	Tyree	Daye					male		graduate	North Carolina State University			winner	Whiting Foundation	Whiting Award	2019	no genre	career	50000.0	
 610	Doug Wright	Doug	Wright	Q722807	Doug Wright	19889397	no2005081836	male	Yale University	graduate	New York University			judge	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2011	no genre	career	50000.0	
 610	Doug Wright	Doug	Wright	Q722807	Doug Wright	19889397	no2005081836	male	Yale University	graduate	New York University			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2010	no genre	career	50000.0	
 2282	Tyehimba Jess	Tyehimba	Jess	Q15441431	Tyehimba Jess	58785478	no2004014919	male	University of Chicago	graduate	New York University			winner	Lannan Foundation	Lannan Award	2016	poetry	career	150000.0	
 2282	Tyehimba Jess	Tyehimba	Jess	Q15441431	Tyehimba Jess	58785478	no2004014919	male	University of Chicago	graduate	New York University			winner	Whiting Foundation	Whiting Award	2006	no genre	career	50000.0	
-1022	Javier Zamora	Javier	Zamora	Q29451986	Javier Zamora	10151050063933412729		male	Stanford University	graduate	New York University		Stegner	winner	Lannan Foundation	Lannan Fellowship	2017	poetry	career	50000.0	
-1022	Javier Zamora	Javier	Zamora	Q29451986	Javier Zamora	10151050063933412729		male	Stanford University	graduate	New York University		Stegner	winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2016	poetry	career	25800.0	
+1022	Javier Zamora	Javier	Zamora	Q29451986	Javier Zamora	10151050063933412729	n2017026887	male	Stanford University	graduate	New York University		Stegner	winner	Lannan Foundation	Lannan Fellowship	2017	poetry	career	50000.0	
+1022	Javier Zamora	Javier	Zamora	Q29451986	Javier Zamora	10151050063933412729	n2017026887	male	Stanford University	graduate	New York University		Stegner	winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2016	poetry	career	25800.0	
 1144	John Keene	John	Keene	Q6242643	John Keene	75563101	n95062054	male	Harvard University	graduate	New York University			winner	American Academy of Arts and Letters	Harold D. Vursell Memorial Award	2019	prose	career	20000.0	
 1144	John Keene	John	Keene	Q6242643	John Keene	75563101	n95062054	male	Harvard University	graduate	New York University			winner	Lannan Foundation	Lannan Award	2016	prose	career	150000.0	
 1144	John Keene	John	Keene	Q6242643	John Keene	75563101	n95062054	male	Harvard University	graduate	New York University			winner	MacArthur Foundation	MacArthur Fellowship	2018	no genre	career	625000.0	
@@ -2338,15 +2338,15 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 932	Ishion Hutchinson	Ishion	Hutchinson	Q16252560	Ishion Hutchinson			male		graduate	New York University			winner	Whiting Foundation	Whiting Award	2013	no genre	career	50000.0	
 932	Ishion Hutchinson	Ishion	Hutchinson	Q16252560	Ishion Hutchinson			male		graduate	New York University			winner	Yale University	Windham Campbell Prize	2019	prose	career	165000.0	
 1582	Matt Donovan	Matt	Donovan	Q6788574	Matt Donovan	60975538	n2006072593	male		graduate	New York University			winner	Whiting Foundation	Whiting Award	2010	no genre	career	50000.0	
-1663	Mitchell Jackson	Mitchell	Jackson					male		graduate	New York University			winner	Lannan Foundation	Lannan Fellowship	2014	prose	career	50000.0	
-1663	Mitchell Jackson	Mitchell	Jackson					male		graduate	New York University			winner	Whiting Foundation	Whiting Award	2016	no genre	career	50000.0	
+1663	Mitchell Jackson	Mitchell	Jackson	Q26268519	Mitchell S. Jackson	303421633	n2013029105	male		graduate	New York University			winner	Lannan Foundation	Lannan Fellowship	2014	prose	career	50000.0	
+1663	Mitchell Jackson	Mitchell	Jackson	Q26268519	Mitchell S. Jackson	303421633	n2013029105	male		graduate	New York University			winner	Whiting Foundation	Whiting Award	2016	no genre	career	50000.0	
 1711	Neil Labute	Neil	Labute	Q965498	Neil LaBute	84248018	no95009945	male		graduate	New York University			winner	American Academy of Arts and Letters	Arts and Letters Awards	2013	no genre	career	10000.0	
 1745	Ocean Vuong	Ocean	Vuong	Q18355929	Ocean Vuong	17145003693061340818	n2015067141	male		graduate	New York University			winner	Lannan Foundation	Lannan Fellowship	2016	poetry	career	50000.0	
 1745	Ocean Vuong	Ocean	Vuong	Q18355929	Ocean Vuong	17145003693061340818	n2015067141	male		graduate	New York University			winner	MacArthur Foundation	MacArthur Fellowship	2019	no genre	career	625000.0	
 1745	Ocean Vuong	Ocean	Vuong	Q18355929	Ocean Vuong	17145003693061340818	n2015067141	male		graduate	New York University			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2014	poetry	career	25800.0	
 1745	Ocean Vuong	Ocean	Vuong	Q18355929	Ocean Vuong	17145003693061340818	n2015067141	male		graduate	New York University			winner	Whiting Foundation	Whiting Award	2016	no genre	career	50000.0	
-1865	Rajiv Joseph	Rajiv	Joseph					male		graduate	New York University			winner	American Academy of Arts and Letters	Arts and Letters Awards	2014	no genre	career	10000.0	
-1865	Rajiv Joseph	Rajiv	Joseph					male		graduate	New York University			winner	Whiting Foundation	Whiting Award	2009	no genre	career	50000.0	
+1865	Rajiv Joseph	Rajiv	Joseph	Q7286231	Rajiv Joseph	249892167	no2008019607	male		graduate	New York University			winner	American Academy of Arts and Letters	Arts and Letters Awards	2014	no genre	career	10000.0	
+1865	Rajiv Joseph	Rajiv	Joseph	Q7286231	Rajiv Joseph	249892167	no2008019607	male		graduate	New York University			winner	Whiting Foundation	Whiting Award	2009	no genre	career	50000.0	
 266	Brad Kessler	Brad	Kessler	Q4954050	Brad Kessler	16427179	n92098988	male		graduate	New School for Social Research			winner	Whiting Foundation	Whiting Award	2007	no genre	career	50000.0	
 490	Darius Simpson	Darius	Simpson					male		graduate	Mills College			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2020	poetry	career	25800.0	
 15	Adam Johnson	Adam	Johnson	Q4679309	Adam Johnson	119126256	n2001039608	male	Stanford University	graduate	McNeese State University		Stegner	judge	PEN America	Saul Bellow Award For Achievement In American Fiction	2018	prose	career	25000.0	
@@ -2398,10 +2398,10 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1526	Mark Doty	Mark	Doty	Q1563756	Mark Doty	84141526	n79151575	male		graduate	Goddard College			judge	Academy of American Poets	Wallace Stevens Award	2011	poetry	career	100000.0	
 1526	Mark Doty	Mark	Doty	Q1563756	Mark Doty	84141526	n79151575	male		graduate	Goddard College			winner	Whiting Foundation	Whiting Award	1994	no genre	career	50000.0	
 2039	Ryan Call	Ryan	Call	Q20949812	Ryan Call	236612477	no2012050090	male		graduate	George Mason University			winner	Whiting Foundation	Whiting Award	2011	no genre	career	50000.0	
-1484	Manuel Muñoz	Manuel	Muñoz					male	Harvard University, Cornell University	graduate	Cornell University			winner	Whiting Foundation	Whiting Award	2008	no genre	career	50000.0	
+1484	Manuel Muñoz	Manuel	Muñoz	Q15439348	Manuel Muñoz	25801478	n2006073516	male	Harvard University, Cornell University	graduate	Cornell University			winner	Whiting Foundation	Whiting Award	2008	no genre	career	50000.0	
 1248	Junot Diaz	Junot	Diaz	Q402664	Junot Díaz	79142980	n96034971	male	Cornell University	graduate	Cornell University			winner	MacArthur Foundation	MacArthur Fellowship	2012	no genre	career	500000.0	
 1720	Nicholas Friedman	Nicholas	Friedman					male	Cornell University	graduate	Cornell University			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2012	poetry	career	25800.0	
-2004	Rolf Fjelde	Rolf	Fjelde					male	Yale University, Columbia University	graduate	Columbia University			winner	American Academy of Arts and Letters	Arts and Letters Awards	1993	no genre	career	10000.0	
+2004	Rolf Fjelde	Rolf	Fjelde	Q7360725	Rolf G. Fjelde	30828612	n80009970	male	Yale University, Columbia University	graduate	Columbia University			winner	American Academy of Arts and Letters	Arts and Letters Awards	1993	no genre	career	10000.0	
 308	Campbell McGrath	Campbell	McGrath	Q5028114	Campbell McGrath	75419034	n88246386	male	University of Chicago, Columbia University	graduate	Columbia University			judge	Folger Shakespeare Library	O. B. Hardison Poetry Prize	2006	poetry	career	10000.0	
 308	Campbell McGrath	Campbell	McGrath	Q5028114	Campbell McGrath	75419034	n88246386	male	University of Chicago, Columbia University	graduate	Columbia University			judge	Folger Shakespeare Library	O. B. Hardison Poetry Prize	2005	poetry	career	10000.0	
 308	Campbell McGrath	Campbell	McGrath	Q5028114	Campbell McGrath	75419034	n88246386	male	University of Chicago, Columbia University	graduate	Columbia University			judge	Folger Shakespeare Library	O. B. Hardison Poetry Prize	2004	poetry	career	10000.0	
@@ -2410,7 +2410,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2302	Victor Lavalle	Victor	Lavalle	Q7926078	Victor LaValle	165884191	n99023474	male	Cornell University, Columbia University	graduate	Columbia University			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2006	no genre	career	50000.0	
 2302	Victor Lavalle	Victor	Lavalle	Q7926078	Victor LaValle	165884191	n99023474	male	Cornell University, Columbia University	graduate	Columbia University			winner	Whiting Foundation	Whiting Award	2004	no genre	career	50000.0	
 1926	Rick Hilles	Rick	Hilles	Q7331457	Rick Hilles	39152380049401761461	no00045634	male	Columbia University, Stanford University	graduate	Columbia University		Stegner	winner	Whiting Foundation	Whiting Award	2008	no genre	career	50000.0	
-410	Clarence Coo	Clarence	Coo	Q1095459	Clarence Cooper, Jr.	94353134	n84054940	male	Columbia University	graduate	Columbia University			winner	Whiting Foundation	Whiting Award	2017	no genre	career	50000.0	
+410	Clarence Coo	Clarence	Coo					male	Columbia University	graduate	Columbia University			winner	Whiting Foundation	Whiting Award	2017	no genre	career	50000.0	
 446	Cyree Jarelle Johnson	Cyree Jarelle	Johnson	Q99772980	Cyrée Jarelle Johnson			male	Columbia University	graduate	Columbia University			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2020	poetry	career	25800.0	
 580	Dinaw Mengestu	Dinaw	Mengestu	Q3028276	Dinaw Mengestu	56040841	n2006058630	male	Columbia University	graduate	Columbia University			winner	Lannan Foundation	Lannan Fellowship	2007	prose	career	50000.0	
 580	Dinaw Mengestu	Dinaw	Mengestu	Q3028276	Dinaw Mengestu	56040841	n2006058630	male	Columbia University	graduate	Columbia University			winner	MacArthur Foundation	MacArthur Fellowship	2012	no genre	career	500000.0	
@@ -2438,7 +2438,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1580	Mat Johnson	Mat	Johnson	Q6785827	Mat Johnson	166506824	n99021541	male	Columbia University	graduate	Columbia University			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2007	no genre	career	50000.0	
 1589	Matthew Stadler	Matthew	Stadler	Q3728594	Matthew Stadler	93250504	n90601027	male	Columbia University	graduate	Columbia University			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2006	no genre	career	50000.0	
 1589	Matthew Stadler	Matthew	Stadler	Q3728594	Matthew Stadler	93250504	n90601027	male	Columbia University	graduate	Columbia University			winner	Whiting Foundation	Whiting Award	1995	no genre	career	50000.0	
-1949	Robert Cohen	Robert	Cohen	Q3434831	Robert Cohen			male	Columbia University	graduate	Columbia University			winner	Whiting Foundation	Whiting Award	2000	no genre	career	50000.0	
+1949	Robert Cohen	Robert	Cohen	Q20878812	Robert Cohen	91948697	n87929592	male	Columbia University	graduate	Columbia University			winner	Whiting Foundation	Whiting Award	2000	no genre	career	50000.0	
 2305	Vijay Seshadri	Vijay	Seshadri	Q7929205	Vijay Seshadri	1733248	n96038513	male	Columbia University	graduate	Columbia University			winner	American Academy of Arts and Letters	Arts and Letters Awards	2015	no genre	career	10000.0	
 2305	Vijay Seshadri	Vijay	Seshadri	Q7929205	Vijay Seshadri	1733248	n96038513	male	Columbia University	graduate	Columbia University			judge	Poets & Writers	Jackson Poetry Prize	2015	poetry	career	75000.0	
 1928	Rick Moody	Rick	Moody	Q709368	Rick Moody	2604389	nr92020208	male	Brown University, Columbia University	graduate	Columbia University			winner	American Academy of Arts and Letters	Arts and Letters Awards	2018	no genre	career	10000.0	
@@ -2487,30 +2487,30 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 505	David Bromwich	David	Bromwich	Q5231783	David Bromwich	2485954	n79069634	male	Yale University	graduate				judge	Yale University	Bollingen Prize for Poetry	1991	poetry	career	10000.0	
 540	David Quammen	David	Quammen	Q1176215	David Quammen	37032561	n80139796	male	Yale University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1996	no genre	career	10000.0	
 701	Eric Bentley	Eric	Bentley	Q1351104	Eric Bentley	71412301	n79096858	male	Yale University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1953	no genre	career	10000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1974	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1973	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1972	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1971	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1970	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1969	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1968	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1967	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1966	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1965	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1964	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1963	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1962	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1961	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1960	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1959	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1958	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1957	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1956	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1955	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1954	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1953	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1952	poetry	career	25000.0	
-773	Frederick Pottle	Frederick	Pottle					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1950	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1974	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1973	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1972	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1971	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1970	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1969	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1968	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1967	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1966	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1965	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1964	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1963	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1962	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1961	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1960	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1959	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1958	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1957	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1956	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1955	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1954	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1953	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1952	poetry	career	25000.0	
+773	Frederick Pottle	Frederick	Pottle	Q52156914	Frederick A. Pottle	104192291	n79141214	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1950	poetry	career	25000.0	
 828	Gordon Haight	Gordon	Haight					male	Yale University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1970	no genre	career	10000.0	
 883	Henry Seidel Canby	Henry Seidel	Canby	Q15501218	Henry Seidel Canby	7559111	n50051945	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1961	poetry	career	25000.0	
 883	Henry Seidel Canby	Henry Seidel	Canby	Q15501218	Henry Seidel Canby	7559111	n50051945	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1960	poetry	career	25000.0	
@@ -2556,25 +2556,25 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1341	Lane Dunlop	Lane	Dunlop					male	Yale University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1997	no genre	career	10000.0	
 1343	Langdon Hammer	Langdon	Hammer					male	Yale University	graduate				judge	Yale University	Bollingen Prize for Poetry	2007	poetry	career	10000.0	
 1343	Langdon Hammer	Langdon	Hammer					male	Yale University	graduate				judge	Yale University	Bollingen Prize for Poetry	1999	poetry	career	10000.0	
-1739	Norman Pearson	Norman	Pearson	Q16065901	John Norman Pearson	76069026	no2006052284	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1976	poetry	career	25000.0	
-1739	Norman Pearson	Norman	Pearson	Q16065901	John Norman Pearson	76069026	no2006052284	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1975	poetry	career	25000.0	
-1739	Norman Pearson	Norman	Pearson	Q16065901	John Norman Pearson	76069026	no2006052284	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1974	poetry	career	25000.0	
-1739	Norman Pearson	Norman	Pearson	Q16065901	John Norman Pearson	76069026	no2006052284	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1973	poetry	career	25000.0	
-1739	Norman Pearson	Norman	Pearson	Q16065901	John Norman Pearson	76069026	no2006052284	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1972	poetry	career	25000.0	
-1739	Norman Pearson	Norman	Pearson	Q16065901	John Norman Pearson	76069026	no2006052284	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1971	poetry	career	25000.0	
-1739	Norman Pearson	Norman	Pearson	Q16065901	John Norman Pearson	76069026	no2006052284	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1970	poetry	career	25000.0	
-1739	Norman Pearson	Norman	Pearson	Q16065901	John Norman Pearson	76069026	no2006052284	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1969	poetry	career	25000.0	
-1739	Norman Pearson	Norman	Pearson	Q16065901	John Norman Pearson	76069026	no2006052284	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1968	poetry	career	25000.0	
-1739	Norman Pearson	Norman	Pearson	Q16065901	John Norman Pearson	76069026	no2006052284	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1967	poetry	career	25000.0	
-1739	Norman Pearson	Norman	Pearson	Q16065901	John Norman Pearson	76069026	no2006052284	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1966	poetry	career	25000.0	
-1739	Norman Pearson	Norman	Pearson	Q16065901	John Norman Pearson	76069026	no2006052284	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1965	poetry	career	25000.0	
-1739	Norman Pearson	Norman	Pearson	Q16065901	John Norman Pearson	76069026	no2006052284	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1964	poetry	career	25000.0	
+1739	Norman Pearson	Norman	Pearson					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1976	poetry	career	25000.0	
+1739	Norman Pearson	Norman	Pearson	Q7052354	Norman Holmes Pearson	27082572	n78090522	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1975	poetry	career	25000.0	
+1739	Norman Pearson	Norman	Pearson	Q7052354	Norman Holmes Pearson	27082572	n78090522	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1974	poetry	career	25000.0	
+1739	Norman Pearson	Norman	Pearson	Q7052354	Norman Holmes Pearson	27082572	n78090522	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1973	poetry	career	25000.0	
+1739	Norman Pearson	Norman	Pearson	Q7052354	Norman Holmes Pearson	27082572	n78090522	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1972	poetry	career	25000.0	
+1739	Norman Pearson	Norman	Pearson	Q7052354	Norman Holmes Pearson	27082572	n78090522	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1971	poetry	career	25000.0	
+1739	Norman Pearson	Norman	Pearson	Q7052354	Norman Holmes Pearson	27082572	n78090522	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1970	poetry	career	25000.0	
+1739	Norman Pearson	Norman	Pearson	Q7052354	Norman Holmes Pearson	27082572	n78090522	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1969	poetry	career	25000.0	
+1739	Norman Pearson	Norman	Pearson	Q7052354	Norman Holmes Pearson	27082572	n78090522	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1968	poetry	career	25000.0	
+1739	Norman Pearson	Norman	Pearson	Q7052354	Norman Holmes Pearson	27082572	n78090522	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1967	poetry	career	25000.0	
+1739	Norman Pearson	Norman	Pearson	Q7052354	Norman Holmes Pearson	27082572	n78090522	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1966	poetry	career	25000.0	
+1739	Norman Pearson	Norman	Pearson	Q7052354	Norman Holmes Pearson	27082572	n78090522	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1965	poetry	career	25000.0	
+1739	Norman Pearson	Norman	Pearson	Q7052354	Norman Holmes Pearson	27082572	n78090522	male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1964	poetry	career	25000.0	
 1759	P. M. Pasinetti	P. M.	Pasinetti	Q369533	P. M. Pasinetti	36929388	n79079458	male	Yale University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1965	no genre	career	10000.0	
 1954	Robert Fagles	Robert	Fagles					male	Yale University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1996	no genre	career	10000.0	
 1967	Robert Hutchins	Robert	Hutchins					male	Yale University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1946	poetry	career	25000.0	
-1981	Robert Phillips	Robert	Phillips					male	Yale University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1987	no genre	career	10000.0	
+1981	Robert Phillips	Robert	Phillips	Q7348886	Robert Phillips	108961346	n78096860	male	Yale University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1987	no genre	career	10000.0	
 2266	Tom Wolfe	Tom	Wolfe	Q216195	Tom Wolfe	119067502	n79062804	male	Yale University	graduate				winner	American Academy of Arts and Letters	Harold D. Vursell Memorial Award	1980	prose	career	20000.0	
-2371	William Matthews	William	Matthews					male	Yale University	graduate				winner	Poetry Foundation	Ruth Lilly Poetry Prize	1997	poetry	career	100000.0	
+2371	William Matthews	William	Matthews	Q8015241	William Matthews	56838912	n78092891	male	Yale University	graduate				winner	Poetry Foundation	Ruth Lilly Poetry Prize	1997	poetry	career	100000.0	
 809	Gerald Early	Gerald	Early	Q5549097	Gerald Early	236854770	n86837051	male	University of Pennsylvania, Cornell University	graduate				winner	Whiting Foundation	Whiting Award	1988	no genre	career	50000.0	
 550	Davidh Bradley	Davidh	Bradley					male	University of Pennsylvania	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1982	no genre	career	10000.0	
 637	Edward Hirsch	Edward	Hirsch	Q5343460	Edward Hirsch	46805662	n80153675	male	University of Pennsylvania	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	2014	poetry	career	25000.0	
@@ -2635,12 +2635,12 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1843	Philip Roth	Philip	Roth	Q187019	Philip Roth	100235370	n79125808	male	University of Chicago	graduate				judge	PEN America	Saul Bellow Award For Achievement In American Fiction	2010	prose	career	25000.0	
 1843	Philip Roth	Philip	Roth	Q187019	Philip Roth	100235370	n79125808	male	University of Chicago	graduate				judge	PEN America	Saul Bellow Award For Achievement In American Fiction	2009	prose	career	25000.0	
 1843	Philip Roth	Philip	Roth	Q187019	Philip Roth	100235370	n79125808	male	University of Chicago	graduate				winner	PEN America	Saul Bellow Award For Achievement In American Fiction	2007	prose	career	25000.0	
-1855	R. S. Jones	R. S.	Jones					male	University of Chicago	graduate				winner	Whiting Foundation	Whiting Award	1992	no genre	career	50000.0	
+1855	R. S. Jones	R. S.	Jones	Q7273412	R.S. Jones	13938581	n91070799	male	University of Chicago	graduate				winner	Whiting Foundation	Whiting Award	1992	no genre	career	50000.0	
 1924	Rick Atkinson	Rick	Atkinson	Q7331205	Rick Atkinson	61612436	n88252657	male	University of Chicago	graduate				winner	Tulsa Library Trust	Helmerich Distinguished Author Award	2015	prose	career	40000.0	
 1950	Robert Coover	Robert	Coover	Q1282338	Robert Coover	99874615	n80038251	male	University of Chicago	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1976	no genre	career	10000.0	
 1950	Robert Coover	Robert	Coover	Q1282338	Robert Coover	99874615	n80038251	male	University of Chicago	graduate				winner	Lannan Foundation	Lannan Award	2000	prose	career	150000.0	
 518	David Henry Hwang	David Henry	Hwang	Q329897	David Henry Hwang	34580950	n82071627	male	Stanford University, Yale University	graduate				winner	Ford Foundation	Art of Change	2017	no genre	career	50000.0	
-49	Albert Guerard	Albert	Guerard					male	Stanford University, Harvard University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1998	no genre	career	10000.0	
+49	Albert Guerard	Albert	Guerard	Q4710533	Albert J. Guerard	67760832	n80051525	male	Stanford University, Harvard University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1998	no genre	career	10000.0	
 45	Alan Shapiro	Alan	Shapiro	Q4707746	Alan Shapiro	32211496	n83068994	male	Stanford University	graduate			Stegner	winner	American Academy of Arts and Letters	Arts and Letters Awards	2002	no genre	career	10000.0	
 45	Alan Shapiro	Alan	Shapiro	Q4707746	Alan Shapiro	32211496	n83068994	male	Stanford University	graduate			Stegner	winner	Folger Shakespeare Library	O. B. Hardison Poetry Prize	1999	poetry	career	10000.0	
 62	Alexander Greendale	Alexander	Greendale					male	Stanford University	graduate			Stegner	winner	American Academy of Arts and Letters	Arts and Letters Awards	1945	no genre	career	10000.0	
@@ -2676,13 +2676,13 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 622	Edgar Bowers	Edgar	Bowers	Q3719044	Edgar Bowers	61594012	n85812587	male	Stanford University	graduate			Stegner	winner	American Academy of Arts and Letters	Arts and Letters Awards	1991	no genre	career	10000.0	
 622	Edgar Bowers	Edgar	Bowers	Q3719044	Edgar Bowers	61594012	n85812587	male	Stanford University	graduate			Stegner	winner	Yale University	Bollingen Prize for Poetry	1989	poetry	career	10000.0	
 713	Ernest J. Gaines	Ernest J.	Gaines	Q673217	Ernest J. Gaines	85689714	n50015467	male	Stanford University	graduate			Stegner	winner	American Academy of Arts and Letters	Arts and Letters Awards	1987	no genre	career	10000.0	
-726	Evan Connell	Evan	Connell					male	Stanford University	graduate			Stegner	winner	American Academy of Arts and Letters	Arts and Letters Awards	1987	no genre	career	10000.0	
-726	Evan Connell	Evan	Connell					male	Stanford University	graduate			Stegner	winner	Lannan Foundation	Lannan Award	2000	no genre	career	200000.0	
+726	Evan Connell	Evan	Connell	Q2693491	Evan S. Connell	97745717	n50000126	male	Stanford University	graduate			Stegner	winner	American Academy of Arts and Letters	Arts and Letters Awards	1987	no genre	career	10000.0	
+726	Evan Connell	Evan	Connell	Q2693491	Evan S. Connell	97745717	n50000126	male	Stanford University	graduate			Stegner	winner	Lannan Foundation	Lannan Award	2000	no genre	career	200000.0	
 946	J. V. Cunningham	J. V.	Cunningham	Q6107287	J. V. Cunningham	110147570	n50027716	male	Stanford University	graduate				winner	Academy of American Poets	Academy of American Poets Fellowship	1976	poetry	career	25000.0	
 946	J. V. Cunningham	J. V.	Cunningham	Q6107287	J. V. Cunningham	110147570	n50027716	male	Stanford University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1965	no genre	career	10000.0	
-981	James McMichael	James	McMichael					male	Stanford University	graduate			Stegner	winner	Academy of American Poets	Academy of American Poets Fellowship	2007	poetry	career	25000.0	
-981	James McMichael	James	McMichael					male	Stanford University	graduate			Stegner	winner	American Academy of Arts and Letters	Arthur Rense Prize	1999	poetry	career	20000.0	
-981	James McMichael	James	McMichael					male	Stanford University	graduate			Stegner	winner	Whiting Foundation	Whiting Award	1995	no genre	career	50000.0	
+981	James McMichael	James	McMichael	Q6137617	James L. McMichael	36972039	n50012910	male	Stanford University	graduate			Stegner	winner	Academy of American Poets	Academy of American Poets Fellowship	2007	poetry	career	25000.0	
+981	James McMichael	James	McMichael	Q6137617	James L. McMichael	36972039	n50012910	male	Stanford University	graduate			Stegner	winner	American Academy of Arts and Letters	Arthur Rense Prize	1999	poetry	career	20000.0	
+981	James McMichael	James	McMichael	Q6137617	James L. McMichael	36972039	n50012910	male	Stanford University	graduate			Stegner	winner	Whiting Foundation	Whiting Award	1995	no genre	career	50000.0	
 1020	Jason Sommer	Jason	Sommer	Q6163528	Jason Sommer	44372468	n90621250	male	Stanford University	graduate			Stegner	winner	Whiting Foundation	Whiting Award	2001	no genre	career	50000.0	
 1163	John Peck	John	Peck	Q20890188	John Peck	18488788	n78089019	male	Stanford University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1975	no genre	career	10000.0	
 1163	John Peck	John	Peck	Q20890188	John Peck	18488788	n78089019	male	Stanford University	graduate				judge	Library of Congress	Rebekah Johnson Bobbitt National Prize For Poetry	2000	poetry	career	10000.0	
@@ -2707,7 +2707,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1683	N. Scott Momaday	N. Scott	Momaday	Q736570	N. Scott Momaday	110439963	n50003752	male	Stanford University	graduate			Stegner	winner	American Academy of Arts and Letters	Arts and Letters Awards	1970	no genre	career	10000.0	
 1781	Paul Bowles	Paul	Bowles	Q358342	Paul Bowles	112464042	n79043627	male	Stanford University	graduate			Stegner	winner	American Academy of Arts and Letters	Arts and Letters Awards	1950	no genre	career	10000.0	
 1823	Peter Everwine	Peter	Everwine	Q7173895	Peter Everwine	57963972	n82098494	male	Stanford University	graduate			Stegner	winner	American Academy of Arts and Letters	Arts and Letters Awards	2010	no genre	career	10000.0	
-1867	Ralph Lombreglia	Ralph	Lombreglia	Q7287803	Ralph Lombreglia	45869782		male	Stanford University	graduate			Stegner	winner	Whiting Foundation	Whiting Award	1998	no genre	career	50000.0	
+1867	Ralph Lombreglia	Ralph	Lombreglia	Q7287803	Ralph Lombreglia	45869782	n88262429	male	Stanford University	graduate			Stegner	winner	Whiting Foundation	Whiting Award	1998	no genre	career	50000.0	
 1962	Robert Hass	Robert	Hass	Q370513	Robert Hass	26975	n83039272	male	Stanford University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	2007	poetry	career	25000.0	
 1962	Robert Hass	Robert	Hass	Q370513	Robert Hass	26975	n83039272	male	Stanford University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	2006	poetry	career	25000.0	
 1962	Robert Hass	Robert	Hass	Q370513	Robert Hass	26975	n83039272	male	Stanford University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	2005	poetry	career	25000.0	
@@ -2859,8 +2859,8 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 971	James Hadley Billington	James Hadley	Billington	Q137576	James H. Billington	54202464	n80020417	male	Princeton University	graduate				judge	Library of Congress	Poet Laureate	1987	poetry	career	35000.0	
 978	James Longenbach	James	Longenbach	Q6138205	James Longenbach	14797088	n86828998	male	Princeton University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	2014	no genre	career	10000.0	
 978	James Longenbach	James	Longenbach	Q6138205	James Longenbach	14797088	n86828998	male	Princeton University	graduate				judge	Yale University	Bollingen Prize for Poetry	2005	poetry	career	10000.0	
-985	James Richardson	James	Richardson					male	Princeton University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	2002	no genre	career	10000.0	
-985	James Richardson	James	Richardson					male	Princeton University	graduate				winner	Poets & Writers	Jackson Poetry Prize	2011	poetry	career	75000.0	
+985	James Richardson	James	Richardson	Q6142078	James Richardson	109846678	n84014323	male	Princeton University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	2002	no genre	career	10000.0	
+985	James Richardson	James	Richardson	Q6142078	James Richardson	109846678	n84014323	male	Princeton University	graduate				winner	Poets & Writers	Jackson Poetry Prize	2011	poetry	career	75000.0	
 1158	John McPhee	John	McPhee	Q1701049	John McPhee	92169855	n79076613	male	Princeton University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1977	no genre	career	10000.0	
 1212	Joseph Kerman	Joseph	Kerman					male	Princeton University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1956	no genre	career	10000.0	
 1471	Madison Smart Bell	Madison Smart	Bell					male	Princeton University	graduate				winner	American Academy of Arts and Letters	Mildred And Harold Strauss Livings	2008	prose	career	100000.0	
@@ -3107,7 +3107,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1921	Richardg Stern	Richardg	Stern					male	Harvard University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1968	no genre	career	10000.0	
 1921	Richardg Stern	Richardg	Stern					male	Harvard University	graduate				winner	American Academy of Arts and Letters	Award of Merit Medal in the Novel	1985	prose	career	25000.0	
 1953	Robert D. Richardson	Robert D.	Richardson 	Q7343337	Robert D. Richardson	61574563	n82248492	male	Harvard University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1998	no genre	career	10000.0	
-1957	Robert Francis	Robert	Francis	Q3435133	Robert Francis	44428804	n90645158	male	Harvard University	graduate				winner	Academy of American Poets	Academy of American Poets Fellowship	1984	poetry	career	25000.0	
+1957	Robert Francis	Robert	Francis	Q7344478	Robert Francis	17348776	n79125908	male	Harvard University	graduate				winner	Academy of American Poets	Academy of American Poets Fellowship	1984	poetry	career	25000.0	
 1964	Robert Hillyer	Robert	Hillyer	Q2157568	Robert Hillyer	59464846	n86034262	male	Harvard University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1961	poetry	career	25000.0	
 1964	Robert Hillyer	Robert	Hillyer	Q2157568	Robert Hillyer	59464846	n86034262	male	Harvard University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1960	poetry	career	25000.0	
 1964	Robert Hillyer	Robert	Hillyer	Q2157568	Robert Hillyer	59464846	n86034262	male	Harvard University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1959	poetry	career	25000.0	
@@ -3169,10 +3169,10 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2321	Wallace Stevens	Wallace	Stevens	Q166835	Wallace Stevens	61562486	n79086767	male	Harvard University	graduate				judge	Yale University	Bollingen Prize for Poetry	1954	poetry	career	10000.0	
 2321	Wallace Stevens	Wallace	Stevens	Q166835	Wallace Stevens	61562486	n79086767	male	Harvard University	graduate				judge	Yale University	Bollingen Prize for Poetry	1953	poetry	career	10000.0	
 2321	Wallace Stevens	Wallace	Stevens	Q166835	Wallace Stevens	61562486	n79086767	male	Harvard University	graduate				winner	Yale University	Bollingen Prize for Poetry	1949	poetry	career	10000.0	
-2324	Walter J. Bate	Walter J.	Bate					male	Harvard University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1977	no genre	career	10000.0	
+2324	Walter J. Bate	Walter J.	Bate	Q7965245	Walter Jackson Bate	76378854	n79039769	male	Harvard University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1977	no genre	career	10000.0	
 2352	Willard Spiegelman	Willard	Spiegelman					male	Harvard University	graduate				judge	Yale University	Bollingen Prize for Poetry	2003	poetry	career	10000.0	
 2352	Willard Spiegelman	Willard	Spiegelman					male	Harvard University	graduate				judge	Library of Congress	Rebekah Johnson Bobbitt National Prize For Poetry	2000	poetry	career	10000.0	
-2354	William Alfred	William	Alfred					male	Harvard University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1966	no genre	career	10000.0	
+2354	William Alfred	William	Alfred	Q8004294	William Alfred	53072398	n83208234	male	Harvard University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1966	no genre	career	10000.0	
 2355	William Allen Nielson	William Allen	Nielson					male	Harvard University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1947	poetry	career	25000.0	
 2355	William Allen Nielson	William Allen	Nielson					male	Harvard University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1946	poetry	career	25000.0	
 2372	William Maxwell	William	Maxwell	Q1541271	William Keepers Maxwell, Jr.	114674264	n79065705	male	Harvard University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1958	no genre	career	10000.0	
@@ -3285,10 +3285,10 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 471	Daniel Hoffman	Daniel	Hoffman	Q5217498	Daniel Hoffman	299139437	n79058587	male	Columbia University	graduate				judge	Academy of American Poets	Wallace Stevens Award	1994	poetry	career	100000.0	
 526	David Lehman	David	Lehman	Q4257814	David Lehman	9870036	n80013003	male	Columbia University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1990	no genre	career	10000.0	
 531	David Markson	David	Markson	Q515363	David Markson	73895167	n50070016	male	Columbia University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	2007	no genre	career	10000.0	
-544	David Shapiro	David	Shapiro					male	Columbia University	graduate				winner	American Academy of Arts and Letters	Morton Dauwen Zabel Award	1977	poetry	career	10000.0	
+544	David Shapiro	David	Shapiro	Q5239678	David Shapiro	56627981	n79091147	male	Columbia University	graduate				winner	American Academy of Arts and Letters	Morton Dauwen Zabel Award	1977	poetry	career	10000.0	
 590	Donald Finkel	Donald	Finkel	Q5294356	Donald Finkel	57853562	n50005167	male	Columbia University	graduate				winner	American Academy of Arts and Letters	Morton Dauwen Zabel Award	1980	poetry	career	10000.0	
 593	Donald Keene	Donald	Keene	Q1240040	Donald Keene	108222247	n50046423	male	Columbia University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1982	no genre	career	10000.0	
-723	Eugened Genovese	Eugened	Genovese					male	Columbia University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1976	no genre	career	10000.0	
+723	Eugened Genovese	Eugened	Genovese	Q5407291	Eugene Genovese	109673816	n80162287	male	Columbia University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1976	no genre	career	10000.0	
 754	Frank Graham	Frank	Graham					male	Columbia University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1947	poetry	career	25000.0	
 754	Frank Graham	Frank	Graham					male	Columbia University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1946	poetry	career	25000.0	
 770	Frederick Busch	Frederick	Busch	Q1452813	Frederick Busch	110494254	n79102784	male	Columbia University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1986	no genre	career	10000.0	
@@ -3388,7 +3388,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1429	Louis Simpson	Louis	Simpson	Q1871997	Louis Simpson	7509913	n50023694	male	Columbia University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1976	no genre	career	10000.0	
 1429	Louis Simpson	Louis	Simpson	Q1871997	Louis Simpson	7509913	n50023694	male	Columbia University	graduate				judge	Yale University	Bollingen Prize for Poetry	1977	poetry	career	10000.0	
 1431	Louis Zukovsky	Louis	Zukovsky					male	Columbia University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1976	no genre	career	10000.0	
-1466	M. B. Tolson	M. B.	Tolson					male	Columbia University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1966	no genre	career	10000.0	
+1466	M. B. Tolson	M. B.	Tolson	Q3854319	Melvin B. Tolson	34476096	n79054449	male	Columbia University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1966	no genre	career	10000.0	
 1541	Mark Van Doren	Mark	Van Doren	Q975491	Mark Van Doren	12331775	n79100719	male	Columbia University	graduate				winner	Academy of American Poets	Academy of American Poets Fellowship	1967	poetry	career	25000.0	
 1541	Mark Van Doren	Mark	Van Doren	Q975491	Mark Van Doren	12331775	n79100719	male	Columbia University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1952	poetry	career	25000.0	
 1541	Mark Van Doren	Mark	Van Doren	Q975491	Mark Van Doren	12331775	n79100719	male	Columbia University	graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1950	poetry	career	25000.0	
@@ -3449,11 +3449,11 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2214	Theodore Weiss	Theodore	Weiss	Q7782096	Theodore Weiss	20784942	n79056820	male	Columbia University	graduate				judge	Yale University	Bollingen Prize for Poetry	1965	poetry	career	10000.0	
 2273	Tony Kushner	Tony	Kushner	Q704433	Tony Kushner	97980128	n86061581	male	Columbia University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1994	no genre	career	10000.0	
 2273	Tony Kushner	Tony	Kushner	Q704433	Tony Kushner	97980128	n86061581	male	Columbia University	graduate				winner	Whiting Foundation	Whiting Award	1990	no genre	career	50000.0	
-2397	Xj Kennedy	Xj	Kennedy					male	Columbia University	graduate				winner	Poets & Writers	Jackson Poetry Prize	2015	poetry	career	75000.0	
+2397	Xj Kennedy	Xj	Kennedy	Q8041616	X. J. Kennedy	105518937	n79018506	male	Columbia University	graduate				winner	Poets & Writers	Jackson Poetry Prize	2015	poetry	career	75000.0	
 1038	Jeffrey Eugenides	Jeffrey	Eugenides	Q357108	Jeffrey Eugenides	37015518	n92097279	male	Brown University, Stanford University	graduate				winner	American Academy of Arts and Letters	Harold D. Vursell Memorial Award	1995	prose	career	20000.0	
 1038	Jeffrey Eugenides	Jeffrey	Eugenides	Q357108	Jeffrey Eugenides	37015518	n92097279	male	Brown University, Stanford University	graduate				winner	Whiting Foundation	Whiting Award	1993	no genre	career	50000.0	
 2224	Thomas Mallon	Thomas	Mallon	Q7792146	Thomas Mallon	85430101	n82162268	male	Brown University, Harvard University	graduate				winner	American Academy of Arts and Letters	Harold D. Vursell Memorial Award	2011	prose	career	20000.0	
-206	Ayad Akhtar	Ayad	Akhtar					male	Brown University, Columbia University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	2017	no genre	career	10000.0	
+206	Ayad Akhtar	Ayad	Akhtar	Q4830797	Ayad Akhtar	19124904	n2007001005	male	Brown University, Columbia University	graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	2017	no genre	career	10000.0	
 587	Don Share	Don	Share	Q5293504	Don Share	55730698	n88642863	male	Brown University	graduate				judge	Poetry Foundation	Ruth Lilly Poetry Prize	2017	poetry	career	100000.0	
 587	Don Share	Don	Share	Q5293504	Don Share	55730698	n88642863	male	Brown University	graduate				judge	Poetry Foundation	Ruth Lilly Poetry Prize	2016	poetry	career	100000.0	
 587	Don Share	Don	Share	Q5293504	Don Share	55730698	n88642863	male	Brown University	graduate				judge	Poetry Foundation	Ruth Lilly Poetry Prize	2015	poetry	career	100000.0	
@@ -3482,7 +3482,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 89	Alistair Macleod	Alistair	Macleod	Q1659739	Alistair MacLeod	76490556	n85286919	male		graduate				winner	Lannan Foundation	Lannan Award	2003	prose	career	150000.0	
 102	Amitav Ghosh	Amitav	Ghosh	Q336125	Amitav Ghosh	261269554	n85027450	male		graduate				winner	Ford Foundation	Art of Change	2017	no genre	career	50000.0	
 103	Amitava Kumar	Amitava	Kumar	Q4746925	Amitava Kumar	115778900	n97027798	male		graduate				winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2016	no genre	career	50000.0	
-114	An Wilson	An	Wilson					male		graduate				winner	American Academy of Arts and Letters	E. M. Forster Award	1989	no genre	career	10000.0	
+114	An Wilson	An	Wilson	Q211029	Edward O. Wilson	104215813	n79018099	male		graduate				winner	American Academy of Arts and Letters	E. M. Forster Award	1989	no genre	career	10000.0	
 132	Angel Ysaguirre	Angel	Ysaguirre					male		graduate				judge	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2019	no genre	career	50000.0	
 208	B. H. Fairchild	B. H.	Fairchild	Q4834012	B. H. Fairchild	75149721	n80062669	male		graduate				winner	American Academy of Arts and Letters	Arthur Rense Prize	2002	poetry	career	20000.0	
 208	B. H. Fairchild	B. H.	Fairchild	Q4834012	B. H. Fairchild	75149721	n80062669	male		graduate				winner	Library of Congress	Rebekah Johnson Bobbitt National Prize For Poetry	2004	poetry	career	10000.0	
@@ -3497,7 +3497,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 255	Blake Morrison	Blake	Morrison	Q3640836	Blake Morrison	108638782	n79150984	male		graduate				winner	American Academy of Arts and Letters	E. M. Forster Award	1988	no genre	career	10000.0	
 269	Bradford Morrow	Bradford	Morrow	Q4954722	Bradford Morrow	59107135	n78053224	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1998	no genre	career	10000.0	
 279	Brewster Ghiselin	Brewster	Ghiselin	Q4962753	Brewster Ghiselin	97844400	n80057026	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1970	no genre	career	10000.0	
-296	Bruce Smith	Bruce	Smith					male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	2010	no genre	career	10000.0	
+296	Bruce Smith	Bruce	Smith	Q4978301	Bruce Smith	56627056	n83021797	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	2010	no genre	career	10000.0	
 297	Bruce Weigl	Bruce	Weigl	Q4978445	Bruce Weigl	115150664	n78072493	male		graduate				winner	Lannan Foundation	Lannan Award	2006	poetry	career	150000.0	
 309	Carl Dennis	Carl	Dennis	Q5040035	Carl Dennis	64133290	n79062703	male		graduate				winner	Poetry Foundation	Ruth Lilly Poetry Prize	2000	poetry	career	100000.0	
 344	Charles Baxter	Charles	Baxter	Q5075480	Charles Baxter	103170636	n88040611	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1997	no genre	career	10000.0	
@@ -3521,7 +3521,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 508	David Cope	David	Cope					male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1988	no genre	career	10000.0	
 514	David Gewanter	David	Gewanter	Q5234101	David Gewanter	37148350	n96037032	male		graduate				winner	Whiting Foundation	Whiting Award	2002	no genre	career	50000.0	
 524	David Krump	David	Krump					male		graduate				winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2006	poetry	career	25800.0	
-536	David Mitchell	David	Mitchell	Q40479	David Mitchell	85328187	n00022382	male		graduate				winner	American Academy of Arts and Letters	E. M. Forster Award	2012	no genre	career	10000.0	
+536	David Mitchell	David	Mitchell	Q72964346	David Mitchell	102371618	n50033569	male		graduate				winner	American Academy of Arts and Letters	E. M. Forster Award	2012	no genre	career	10000.0	
 541	David Rabe	David	Rabe	Q497375	David Rabe	17346689	n79148174	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1974	no genre	career	10000.0	
 546	David Wagoner	David	Wagoner	Q5240765	David Wagoner	115610603	n80010019	male		graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1999	poetry	career	25000.0	
 546	David Wagoner	David	Wagoner	Q5240765	David Wagoner	115610603	n80010019	male		graduate				judge	Academy of American Poets	Academy of American Poets Fellowship	1998	poetry	career	25000.0	
@@ -3556,7 +3556,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 546	David Wagoner	David	Wagoner	Q5240765	David Wagoner	115610603	n80010019	male		graduate				judge	Academy of American Poets	Wallace Stevens Award	1994	poetry	career	100000.0	
 573	Dennis O'Driscoll	Dennis	O'Driscoll	Q5258804	Dennis O'Driscoll	118976934	n85087972	male		graduate				winner	American Academy of Arts and Letters	E. M. Forster Award	2005	no genre	career	10000.0	
 573	Dennis O'Driscoll	Dennis	O'Driscoll	Q5258804	Dennis O'Driscoll	118976934	n85087972	male		graduate				winner	Lannan Foundation	Lannan Award	2012	poetry	career	150000.0	
-584	Don Bartlett	Don	Bartlett	Q28378430	Don Bartletti			male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	2014	no genre	career	10000.0	
+584	Don Bartlett	Don	Bartlett					male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	2014	no genre	career	10000.0	
 621	Ed Roberson	Ed	Roberson	Q5335329	Ed Roberson	76415599	nr94024991	male		graduate				winner	Academy of American Poets	Academy of American Poets Fellowship	2017	poetry	career	25000.0	
 621	Ed Roberson	Ed	Roberson	Q5335329	Ed Roberson	76415599	nr94024991	male		graduate				winner	Poetry Foundation	Ruth Lilly Poetry Prize	2016	poetry	career	100000.0	
 641	Edward Snow	Edward	Snow	Q5345371	Edward Snow	15470091	n80027812	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1998	no genre	career	10000.0	
@@ -3572,8 +3572,8 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 741	Forrest Gander	Forrest	Gander	Q5470470	Forrest Gander	17296979	n87931071	male		graduate				judge	Academy of American Poets	Wallace Stevens Award	2018	poetry	career	100000.0	
 741	Forrest Gander	Forrest	Gander	Q5470470	Forrest Gander	17296979	n87931071	male		graduate				winner	Whiting Foundation	Whiting Award	1997	no genre	career	50000.0	
 768	Frederic Tuten	Frederic	Tuten	Q2793520	Frederic Tuten	100238761	n88117173	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	2001	no genre	career	10000.0	
-801	George Elliott	George	Elliott					male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1969	no genre	career	10000.0	
-802	George Evans	George	Evans	Q1378188	Frederick Schiller Faust	251180462	n88121488	male		graduate				winner	Lannan Foundation	Lannan Fellowship	2003	poetry	career	50000.0	
+801	George Elliott	George	Elliott	Q5538961	George Elliott	105871072	n86150102	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1969	no genre	career	10000.0	
+802	George Evans	George	Evans	Q5539043	George Evans	220827744	nb2011031299	male		graduate				winner	Lannan Foundation	Lannan Fellowship	2003	poetry	career	50000.0	
 807	George Saunders	George	Saunders	Q1251926	George Saunders	49395618	n95046060	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	2009	no genre	career	10000.0	
 807	George Saunders	George	Saunders	Q1251926	George Saunders	49395618	n95046060	male		graduate				winner	Lannan Foundation	Lannan Fellowship	2001	prose	career	50000.0	
 807	George Saunders	George	Saunders	Q1251926	George Saunders	49395618	n95046060	male		graduate				winner	MacArthur Foundation	MacArthur Fellowship	2006	no genre	career	500000.0	
@@ -3593,7 +3593,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 919	Ilya Kaminsky	Ilya	Kaminsky	Q6001433	Ilya Kaminsky	151608904	no2002110887	male		graduate				winner	American Academy of Arts and Letters	Metcalf Awards	2005	no genre	career	10000.0	
 919	Ilya Kaminsky	Ilya	Kaminsky	Q6001433	Ilya Kaminsky	151608904	no2002110887	male		graduate				winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2001	poetry	career	25800.0	
 919	Ilya Kaminsky	Ilya	Kaminsky	Q6001433	Ilya Kaminsky	151608904	no2002110887	male		graduate				winner	Whiting Foundation	Whiting Award	2005	no genre	career	50000.0	
-945	J. S. Marcus	J. S.	Marcus					male		graduate				winner	Whiting Foundation	Whiting Award	1992	no genre	career	50000.0	
+945	J. S. Marcus	J. S.	Marcus	Q15485176	J.S. Marcus	33622683	n90676301	male		graduate				winner	Whiting Foundation	Whiting Award	1992	no genre	career	50000.0	
 947	Jack Gilbert	Jack	Gilbert	Q2793945	Jack Gilbert	114247104	n81122737	male		graduate				winner	Lannan Foundation	Lannan Award	1994	poetry	career	150000.0	
 991	James Seay	James	Seay					male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1988	no genre	career	10000.0	
 993	James Still	James	Still	Q6143675	James Still	32065854	n50011350	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1947	no genre	career	10000.0	
@@ -3624,9 +3624,9 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1127	John Gardner	John	Gardner	Q1381985	John Gardner	2470610	n79056152	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1975	no genre	career	10000.0	
 1129	John Gray	John	Gray	Q129130	John Gray	93173540	n92001650	male		graduate				winner	Lannan Foundation	Lannan Award	2008	no genre	career	150000.0	
 1130	John Grisham	John	Grisham	Q106465	John Grisham	7449742	n88231236	male		graduate				winner	Tulsa Library Trust	Helmerich Distinguished Author Award	2005	prose	career	40000.0	
-1138	John Holman	John	Holman					male		graduate				winner	Whiting Foundation	Whiting Award	1991	no genre	career	50000.0	
-1151	John Logan	John	Logan	Q384004	John Logan	104842082	n96057236	male		graduate				winner	American Academy of Arts and Letters	Morton Dauwen Zabel Award	1974	poetry	career	10000.0	
-1171	John Williams	John	Williams	Q2077062	John Edward Williams	67710786	n79045254	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1985	no genre	career	10000.0	
+1138	John Holman	John	Holman	Q6239649	John Holman	33559296	n88206712	male		graduate				winner	Whiting Foundation	Whiting Award	1991	no genre	career	50000.0	
+1151	John Logan	John	Logan	Q6245151	John Logan	85933786	n50039516	male		graduate				winner	American Academy of Arts and Letters	Morton Dauwen Zabel Award	1974	poetry	career	10000.0	
+1171	John Williams	John	Williams	Q21481534	John Williams	85471424	n96102581	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1985	no genre	career	10000.0	
 1183	Jonah Mixon-Webster	Jonah	Mixon-Webster					male		graduate				winner	Yale University	Windham Campbell Prize	2020	poetry	career	165000.0	
 1197	Jorge Guillen	Jorge	Guillen	Q59837	Jorge Guillén	91629318	n85092317	male		graduate				winner	American Academy of Arts and Letters	Award of Merit Medal in Poetry	1955	poetry	career	25000.0	
 1202	Josegarcia Villa	Josegarcia	Villa					male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1943	no genre	career	10000.0	
@@ -3658,9 +3658,9 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1393	Li-Young Lee	Li-Young	Lee	Q6538613	Li-Young Lee	66534937	n88615728	male		graduate				winner	Lannan Foundation	Lannan Award	1995	poetry	career	150000.0	
 1393	Li-Young Lee	Li-Young	Lee	Q6538613	Li-Young Lee	66534937	n88615728	male		graduate				winner	Whiting Foundation	Whiting Award	1988	no genre	career	50000.0	
 1433	Louis de Bernières	Louis de	Bernières	Q712191	Louis de Bernières	117616243	n91034779	male		graduate				winner	Lannan Foundation	Lannan Award	1995	prose	career	150000.0	
-1428	Louis Rubin	Louis	Rubin					male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	2004	no genre	career	10000.0	
-1428	Louis Rubin	Louis	Rubin					male		graduate				judge	Yale University	Bollingen Prize for Poetry	1985	poetry	career	10000.0	
-1441	Lucas Hnath	Lucas	Hnath					male		graduate				winner	Whiting Foundation	Whiting Award	2015	no genre	career	50000.0	
+1428	Louis Rubin	Louis	Rubin	Q15993456	Louis D. Rubin, Jr.	108283788	n79058685	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	2004	no genre	career	10000.0	
+1428	Louis Rubin	Louis	Rubin	Q15993456	Louis D. Rubin, Jr.	108283788	n79058685	male		graduate				judge	Yale University	Bollingen Prize for Poetry	1985	poetry	career	10000.0	
+1441	Lucas Hnath	Lucas	Hnath	Q21067304	Lucas Hnath	307451527	no2014005773	male		graduate				winner	Whiting Foundation	Whiting Award	2015	no genre	career	50000.0	
 1518	Marius Bewley	Marius	Bewley					male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1973	no genre	career	10000.0	
 1527	Mark Harris	Mark	Harris	Q1413561	Mark Harris	243149196670374792876	n79055594	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1961	no genre	career	10000.0	
 1543	Marlon James	Marlon	James	Q16211564	Marlon James	9583183	no2005086485	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	2018	no genre	career	10000.0	
@@ -3670,7 +3670,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1655	Miller Oberman	Miller	Oberman					male		graduate				winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2005	poetry	career	25800.0	
 1656	Miller Williams	Miller	Williams	Q6859278	Miller Williams	79057014	n79126520	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1995	no genre	career	10000.0	
 1675	Morgan Meis	Morgan	Meis					male		graduate				winner	Whiting Foundation	Whiting Award	2013	no genre	career	50000.0	
-1712	Neil Simon	Neil	Simon					male		graduate				winner	Tulsa Library Trust	Helmerich Distinguished Author Award	1996	prose	career	40000.0	
+1712	Neil Simon	Neil	Simon	Q315808	Neil Simon	49253423	n79065574	male		graduate				winner	Tulsa Library Trust	Helmerich Distinguished Author Award	1996	prose	career	40000.0	
 1721	Nicholas Jenkins	Nicholas	Jenkins					male		graduate				judge	Yale University	Bollingen Prize for Poetry	2007	poetry	career	10000.0	
 1740	Norman Rosten	Norman	Rosten	Q3430050	Norman Rosten	56621415	n50049735	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1945	no genre	career	10000.0	
 1821	Peter Dale Scott	Peter Dale	Scott	Q716907	Peter Dale Scott	24729434	n50005959	male		graduate				winner	Lannan Foundation	Lannan Award	2002	poetry	career	150000.0	
@@ -3768,7 +3768,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1980	Robert Penn Warren	Robert Penn	Warren	Q312720	Robert Penn Warren	61553765	n78091524	male		graduate				winner	Library of Congress	Poet Laureate	1986	poetry	career	35000.0	
 1980	Robert Penn Warren	Robert Penn	Warren	Q312720	Robert Penn Warren	61553765	n78091524	male		graduate				winner	Library of Congress	Poet Laureate	1945	poetry	career	35000.0	
 1980	Robert Penn Warren	Robert Penn	Warren	Q312720	Robert Penn Warren	61553765	n78091524	male		graduate				winner	Library of Congress	Poet Laureate	1944	poetry	career	35000.0	
-1987	Robert Watson	Robert	Watson	Q18917394	Robert Watson	77520267	nr93010650	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1977	no genre	career	10000.0	
+1987	Robert Watson	Robert	Watson	Q16854155	Robert Watson	100210641	n85067480	male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1977	no genre	career	10000.0	
 1990	Robertm Pirsig	Robertm	Pirsig					male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1979	no genre	career	10000.0	
 2000	Roger Fanning	Roger	Fanning	Q7358172	Roger Fanning	60718920	n91027693	male		graduate				winner	Whiting Foundation	Whiting Award	1992	no genre	career	50000.0	
 2038	Rv Cassill	Rv	Cassill					male		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1995	no genre	career	10000.0	
@@ -3818,7 +3818,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 401	Christopher Tilghman	Christopher	Tilghman	Q5113331	Christopher Tilghman	69604133	n88283046	male	Yale University					winner	Whiting Foundation	Whiting Award	1990	no genre	career	50000.0	
 534	David McCullough	David	McCullough	Q374610	David McCullough	249930282	n50007726	male	Yale University					winner	Tulsa Library Trust	Helmerich Distinguished Author Award	1995	prose	career	40000.0	
 940	J. D. Landis	J. D.	Landis	Q27063087	J. D. Landis	79381431	n78094653	male	Yale University					winner	American Academy of Arts and Letters	Morton Dauwen Zabel Award	1996	prose	career	10000.0	
-972	James Hannaham	James	Hannaham	Q53567407	James Hannaham	90541044		male	Yale University					winner	American Academy of Arts and Letters	Morton Dauwen Zabel Award	2016	prose	career	10000.0	
+972	James Hannaham	James	Hannaham	Q53567407	James Hannaham	90541044	no2009091146	male	Yale University					winner	American Academy of Arts and Letters	Morton Dauwen Zabel Award	2016	prose	career	10000.0	
 1346	Larry Kramer	Larry	Kramer	Q653366	Larry Kramer	103118671	n78036842	male	Yale University					winner	American Academy of Arts and Letters	Arts and Letters Awards	1996	no genre	career	10000.0	
 1375	Leonard Bacon	Leonard	Bacon	Q6525095	Leonard Bacon	39750079	no96044132	male	Yale University					judge	Academy of American Poets	Academy of American Poets Fellowship	1954	poetry	career	25000.0	
 1375	Leonard Bacon	Leonard	Bacon	Q6525095	Leonard Bacon	39750079	no96044132	male	Yale University					judge	Academy of American Poets	Academy of American Poets Fellowship	1953	poetry	career	25000.0	
@@ -3934,7 +3934,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 14	Adam Hochschild	Adam	Hochschild	Q349777	Adam Hochschild	88069333	n85318056	male	Harvard University					winner	American Academy of Arts and Letters	Arts and Letters Awards	2012	no genre	career	10000.0	
 60	Alex Ross	Alex	Ross	Q952149	Alex Ross	45500225	no2006014344	male	Harvard University					winner	American Academy of Arts and Letters	Arts and Letters Awards	2011	no genre	career	10000.0	
 192	Arthur Kopit	Arthur	Kopit	Q770566	Arthur Kopit	49227489	n82091910	male	Harvard University					winner	American Academy of Arts and Letters	Arts and Letters Awards	1971	no genre	career	10000.0	
-195	Arthur Schlesinger, Jr	Arthur	Schlesinger, Jr					male	Harvard University					winner	American Academy of Arts and Letters	Arts and Letters Awards	1946	no genre	career	10000.0	
+195	Arthur Schlesinger, Jr	Arthur	Schlesinger, Jr	Q435195	Arthur M. Schlesinger	108761227	n50002711	male	Harvard University					winner	American Academy of Arts and Letters	Arts and Letters Awards	1946	no genre	career	10000.0	
 199	Atticus Lish	Atticus	Lish	Q20657191	Atticus Lish	313293712	no2014166736	male	Harvard University					winner	American Academy of Arts and Letters	Harold D. Vursell Memorial Award	2018	prose	career	20000.0	
 251	Bill McKibben	Bill	McKibben	Q503815	Bill McKibben	24639738	n88207642	male	Harvard University					winner	American Academy of Arts and Letters	Arts and Letters Awards	2013	no genre	career	10000.0	
 345	Charles Bernstein	Charles	Bernstein	Q966050	Charles Bernstein	106505739	n84160359	male	Harvard University					winner	Yale University	Bollingen Prize for Poetry	2019	poetry	career	10000.0	
@@ -3949,7 +3949,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 428	Conrad Aiken	Conrad	Aiken	Q380645	Conrad Aiken	71433883	n80060447	male	Harvard University					winner	Library of Congress	Poet Laureate	1952	poetry	career	35000.0	
 428	Conrad Aiken	Conrad	Aiken	Q380645	Conrad Aiken	71433883	n80060447	male	Harvard University					winner	Library of Congress	Poet Laureate	1951	poetry	career	35000.0	
 428	Conrad Aiken	Conrad	Aiken	Q380645	Conrad Aiken	71433883	n80060447	male	Harvard University					winner	Library of Congress	Poet Laureate	1950	poetry	career	35000.0	
-450	D. Nurkse	D.	Nurkse	Q4328114	Dennis Nurkse	33533776	n87942871	male	Harvard University					winner	American Academy of Arts and Letters	Arts and Letters Awards	2009	no genre	career	10000.0	
+450	D. Nurkse	D.	Nurkse					male	Harvard University					winner	American Academy of Arts and Letters	Arts and Letters Awards	2009	no genre	career	10000.0	
 532	David McCombs	David	McCombs					male	Harvard University					winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	1993	poetry	career	15000.0	
 542	David Riesman	David	Riesman	Q504319	David Riesman	54197257	n79026672	male	Harvard University					winner	American Academy of Arts and Letters	Arts and Letters Awards	1954	no genre	career	10000.0	
 572	Dennis Nurske	Dennis	Nurske					male	Harvard University					winner	Whiting Foundation	Whiting Award	1990	no genre	career	50000.0	
@@ -4109,7 +4109,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2358	William Bronk	William	Bronk	Q264694	William Bronk	79048234	n50040537	male	Dartmouth College					winner	Lannan Foundation	Lannan Award	1991	poetry	career	150000.0	
 193	Arthur Laurents	Arthur	Laurents	Q710334	Arthur Laurents	37116781	n85173003	male	Cornell University					winner	American Academy of Arts and Letters	Arts and Letters Awards	1946	no genre	career	10000.0	
 1329	Kurt Vonnegut	Kurt	Vonnegut	Q49074	Kurt Vonnegut	71398958	n79062641	male	Cornell University					winner	American Academy of Arts and Letters	Arts and Letters Awards	1970	no genre	career	10000.0	
-1787	Paul Green	Paul	Green					male	Cornell University					judge	Yale University	Bollingen Prize for Poetry	1948	poetry	career	10000.0	
+1787	Paul Green	Paul	Green	Q704852	Paul Green	14898321	n79056649	male	Cornell University					judge	Yale University	Bollingen Prize for Poetry	1948	poetry	career	10000.0	
 2230	Thomas Pynchon	Thomas	Pynchon	Q35155	Thomas Pynchon	88986700	n79099184	male	Cornell University					winner	American Academy of Arts and Letters	Christopher Lightfoot Walker Award	2018	no genre	career	100000.0	
 2230	Thomas Pynchon	Thomas	Pynchon	Q35155	Thomas Pynchon	88986700	n79099184	male	Cornell University					winner	MacArthur Foundation	MacArthur Fellowship	1988	no genre	career	500000.0	
 2343	Whitney Balliett	Whitney	Balliett	Q2567179	Whitney Balliett	19751400	n50017244	male	Cornell University					winner	American Academy of Arts and Letters	Arts and Letters Awards	1996	no genre	career	10000.0	
@@ -4188,7 +4188,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 120	Andre Alexis	Andre	Alexis	Q4759811	André Alexis	10107885	n95069960	male						winner	Yale University	Windham Campbell Prize	2017	prose	career	165000.0	
 121	Andre Dubus	Andre	Dubus	Q493118	Andre Dubus	110787061	n79134894	male				3855		winner	American Academy of Arts and Letters	Arts and Letters Awards	2012	no genre	career	10000.0	
 127	Andrew O'Hagan	Andrew	O'Hagan	Q4758145	Andrew O'Hagan	87155882	no96052820	male						winner	American Academy of Arts and Letters	E. M. Forster Award	2003	no genre	career	10000.0	
-128	Andrew Pham	Andrew	Pham					male						winner	Whiting Foundation	Whiting Award	2000	no genre	career	50000.0	
+128	Andrew Pham	Andrew	Pham	Q4758991	Andrew X. Pham	98117546	n99020584	male						winner	Whiting Foundation	Whiting Award	2000	no genre	career	50000.0	
 158	Anne Michaels	Anne	Michaels	Q469135	Anne Michaels	98055768	n85224192	male						winner	Lannan Foundation	Lannan Award	1997	prose	career	150000.0	
 161	Anne Stevenson	Anne	Stevenson	Q3753249	Anne Stevenson	110230648	n50023969	male						winner	Lannan Foundation	Lannan Award	2007	no genre	career	200000.0	
 190	Arnost Lustig	Arnost	Lustig	Q258715	Arnošt Lustig	109645153	n78078766	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	2004	no genre	career	10000.0	
@@ -4248,11 +4248,11 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 362	Charles Simic	Charles	Simic	Q722555	Charles Simic	22044	n80043344	male						judge	Academy of American Poets	Wallace Stevens Award	2003	poetry	career	100000.0	
 362	Charles Simic	Charles	Simic	Q722555	Charles Simic	22044	n80043344	male						judge	Academy of American Poets	Wallace Stevens Award	2002	poetry	career	100000.0	
 362	Charles Simic	Charles	Simic	Q722555	Charles Simic	22044	n80043344	male						judge	Academy of American Poets	Wallace Stevens Award	2001	poetry	career	100000.0	
-363	Charles Wilson	Charles	Wilson					male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1968	no genre	career	10000.0	
+363	Charles Wilson	Charles	Wilson	Q5083632	Charles Wilson	733148122920295200009		male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1968	no genre	career	10000.0	
 399	Christopher Middleton	Christopher	Middleton	Q5112874	Christopher Middleton	98056444	n50031368	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	2012	no genre	career	10000.0	
 403	Ciaran Berry	Ciaran	Berry	Q5119130	Ciaran Berry	75766549	n2007044869	male						winner	Whiting Foundation	Whiting Award	2012	no genre	career	50000.0	
-409	Clarence Brown	Clarence	Brown					male						judge	Library of Congress	Rebekah Johnson Bobbitt National Prize For Poetry	2004	poetry	career	10000.0	
-409	Clarence Brown	Clarence	Brown					male						judge	Library of Congress	Rebekah Johnson Bobbitt National Prize For Poetry	2000	poetry	career	10000.0	
+409	Clarence Brown	Clarence	Brown	Q22246729	Clarence Brown	46888277	n83022039	male						judge	Library of Congress	Rebekah Johnson Bobbitt National Prize For Poetry	2004	poetry	career	10000.0	
+409	Clarence Brown	Clarence	Brown	Q22246729	Clarence Brown	46888277	n83022039	male						judge	Library of Congress	Rebekah Johnson Bobbitt National Prize For Poetry	2000	poetry	career	10000.0	
 418	Clifford Thompson	Clifford	Thompson					male						winner	Whiting Foundation	Whiting Award	2013	no genre	career	50000.0	
 424	Colm Toibin	Colm	Toibin	Q470758	Colm Tóibín	32063755	n91025439	male						winner	American Academy of Arts and Letters	E. M. Forster Award	1995	no genre	career	10000.0	
 426	Colum McCann	Colum	McCann	Q966228	Colum McCann	98559644	n95046994	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	2011	no genre	career	10000.0	
@@ -4260,7 +4260,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 430	Cormac McCarthy	Cormac	McCarthy	Q272610	Cormac McCarthy	29558386	n82028392	male						winner	American Academy of Arts and Letters	Award of Merit Medal in the Novel	2015	prose	career	25000.0	
 430	Cormac McCarthy	Cormac	McCarthy	Q272610	Cormac McCarthy	29558386	n82028392	male						winner	MacArthur Foundation	MacArthur Fellowship	1981	no genre	career	500000.0	
 430	Cormac McCarthy	Cormac	McCarthy	Q272610	Cormac McCarthy	29558386	n82028392	male						winner	PEN America	Saul Bellow Award For Achievement In American Fiction	2009	prose	career	25000.0	
-434	Craig Lucas	Craig	Lucas					male						winner	American Academy of Arts and Letters	Arts and Letters Awards	2000	no genre	career	10000.0	
+434	Craig Lucas	Craig	Lucas	Q5181167	Craig Lucas	54336648	n82113597	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	2000	no genre	career	10000.0	
 436	Craig Nova	Craig	Nova	Q5181283	Craig Nova	20293024	n82031955	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1984	no genre	career	10000.0	
 468	Daniel Fuchs	Daniel	Fuchs	Q1160785	Daniel Fuchs	113494754	n79006748	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1962	no genre	career	10000.0	
 486	Danniel Schoonebeek	Danniel	Schoonebeek					male						winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2015	poetry	career	25800.0	
@@ -4268,7 +4268,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 507	David Cook	David	Cook	Q5232542	David Cook	112935564	n81079670	male						winner	American Academy of Arts and Letters	E. M. Forster Award	1977	no genre	career	10000.0	
 519	David Ignatow	David	Ignatow	Q5235338	David Ignatow	91804619	n79119131	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1964	no genre	career	10000.0	
 519	David Ignatow	David	Ignatow	Q5235338	David Ignatow	91804619	n79119131	male						winner	Yale University	Bollingen Prize for Poetry	1977	poetry	career	10000.0	
-520	David Jones	David	Jones	Q260857	David E. H. Jones	94793667	n81148030	male						winner	Yale University	Bollingen Prize for Poetry	1960	poetry	career	10000.0	
+520	David Jones	David	Jones	Q725689	David Jones	121994189	n50039958	male						winner	Yale University	Bollingen Prize for Poetry	1960	poetry	career	10000.0	
 527	David Lindsay-Abaire	David	Lindsay-Abaire	Q532488	David Lindsay-Abaire	24884621	n00032777	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	2012	no genre	career	10000.0	
 529	David Malouf	David	Malouf	Q506430	David Malouf	9850098	n79007021	male						winner	Lannan Foundation	Lannan Award	2000	prose	career	150000.0	
 530	David Mamet	David	Mamet	Q269927	David Mamet	51706396	n77012756	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1986	no genre	career	10000.0	
@@ -4276,7 +4276,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 567	Delmore Schwartz	Delmore	Schwartz	Q1184545	Delmore Schwartz	36934167	n79100468	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1953	no genre	career	10000.0	
 567	Delmore Schwartz	Delmore	Schwartz	Q1184545	Delmore Schwartz	36934167	n79100468	male						winner	Yale University	Bollingen Prize for Poetry	1959	poetry	career	10000.0	
 574	Derek Walcott	Derek	Walcott	Q132701	Derek Walcott	39391959	n79149058	male						winner	MacArthur Foundation	MacArthur Fellowship	1981	no genre	career	500000.0	
-581	Dionisio Martínez	Dionisio	Martínez					male						winner	Whiting Foundation	Whiting Award	1993	no genre	career	50000.0	
+581	Dionisio Martínez	Dionisio	Martínez	Q5279341	Dionisio D. Martinez	53345644	n92058086	male						winner	Whiting Foundation	Whiting Award	1993	no genre	career	50000.0	
 585	Don DeLillo	Don	DeLillo	Q310048	Don DeLillo	17253973	n79059951	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1984	no genre	career	10000.0	
 585	Don DeLillo	Don	DeLillo	Q310048	Don DeLillo	17253973	n79059951	male						judge	PEN America	Saul Bellow Award For Achievement In American Fiction	2012	prose	career	25000.0	
 585	Don DeLillo	Don	DeLillo	Q310048	Don DeLillo	17253973	n79059951	male						winner	PEN America	Saul Bellow Award For Achievement In American Fiction	2010	prose	career	25000.0	
@@ -4301,7 +4301,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 653	Elbert Weinberg	Elbert	Weinberg					male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1968	no genre	career	10000.0	
 703	Eric Hoffer	Eric	Hoffer	Q588692	Eric Hoffer	108655564	n50031284	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1964	no genre	career	10000.0	
 712	Ernest Hemingway	Ernest	Hemingway	Q23434	Ernest Hemingway	97006051	n78078534	male						winner	American Academy of Arts and Letters	Award of Merit Medal in the Novel	1954	prose	career	25000.0	
-719	Ethelbert Miller	Ethelbert	Miller					male						winner	Folger Shakespeare Library	O. B. Hardison Poetry Prize	1995	poetry	career	10000.0	
+719	Ethelbert Miller	Ethelbert	Miller	Q5321846	E. Ethelbert Miller	114284092	n82237045	male						winner	Folger Shakespeare Library	O. B. Hardison Poetry Prize	1995	poetry	career	10000.0	
 732	F. T. Prince	F. T.	Prince	Q5424055	F. T. Prince	79087441	n50021806	male						winner	American Academy of Arts and Letters	E. M. Forster Award	1982	no genre	career	10000.0	
 736	Feike Feikema	Feike	Feikema					male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1945	no genre	career	10000.0	
 752	Frank Chin	Frank	Chin	Q162511	Frank Chin	79042558	n81009693	male						winner	Lannan Foundation	Lannan Award	1992	prose	career	150000.0	
@@ -4352,7 +4352,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 901	Horace Gregory	Horace	Gregory	Q13891091	Horace Gregory	110610574	n50031474	male						winner	Yale University	Bollingen Prize for Poetry	1965	poetry	career	10000.0	
 901	Horace Gregory	Horace	Gregory	Q13891091	Horace Gregory	110610574	n50031474	male						judge	Yale University	Bollingen Prize for Poetry	1958	poetry	career	10000.0	
 901	Horace Gregory	Horace	Gregory	Q13891091	Horace Gregory	110610574	n50031474	male						judge	Yale University	Bollingen Prize for Poetry	1957	poetry	career	10000.0	
-903	Horton Foote	Horton	Foote					male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1995	no genre	career	10000.0	
+903	Horton Foote	Horton	Foote	Q529696	Horton Foote	34482735	n84005993	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1995	no genre	career	10000.0	
 905	Howard Moss	Howard	Moss	Q5920463	Howard Moss	102378315	n80013260	male						judge	Academy of American Poets	Academy of American Poets Fellowship	1988	poetry	career	25000.0	
 905	Howard Moss	Howard	Moss	Q5920463	Howard Moss	102378315	n80013260	male						judge	Academy of American Poets	Academy of American Poets Fellowship	1987	poetry	career	25000.0	
 905	Howard Moss	Howard	Moss	Q5920463	Howard Moss	102378315	n80013260	male						winner	Academy of American Poets	Academy of American Poets Fellowship	1986	poetry	career	25000.0	
@@ -4375,7 +4375,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 966	James Dickey	James	Dickey	Q1377013	James Dickey	109230203	n79043450	male						winner	Library of Congress	Poet Laureate	1968	poetry	career	35000.0	
 966	James Dickey	James	Dickey	Q1377013	James Dickey	109230203	n79043450	male						winner	Library of Congress	Poet Laureate	1967	poetry	career	35000.0	
 966	James Dickey	James	Dickey	Q1377013	James Dickey	109230203	n79043450	male						winner	Library of Congress	Poet Laureate	1966	poetry	career	35000.0	
-999	James F. Powers	James F.	Powers					male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1948	no genre	career	10000.0	
+999	James F. Powers	James F.	Powers	Q1369803	J. F. Powers	110146339	n79063855	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1948	no genre	career	10000.0	
 982	James Merrill	James	Merrill	Q1368437	James Merrill	73866527	n80026113	male						judge	Academy of American Poets	Academy of American Poets Fellowship	1995	poetry	career	25000.0	
 982	James Merrill	James	Merrill	Q1368437	James Merrill	73866527	n80026113	male						judge	Academy of American Poets	Academy of American Poets Fellowship	1994	poetry	career	25000.0	
 982	James Merrill	James	Merrill	Q1368437	James Merrill	73866527	n80026113	male						judge	Academy of American Poets	Academy of American Poets Fellowship	1993	poetry	career	25000.0	
@@ -4405,13 +4405,13 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 989	James Schuyler	James	Schuyler	Q5406329	James Schuyler	29553767	n79091463	male						winner	Whiting Foundation	Whiting Award	1985	no genre	career	50000.0	
 992	James Stern	James	Stern	Q6143588	James Stern	88049337	n50022447	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1949	no genre	career	10000.0	
 997	James Wood	James	Wood	Q528164	James Wood	92910249	n98089526	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	2001	no genre	career	10000.0	
-1067	Jez Butterworth	Jez	Butterworth					male						winner	American Academy of Arts and Letters	E. M. Forster Award	2007	no genre	career	10000.0	
+1067	Jez Butterworth	Jez	Butterworth	Q1688756	Jez Butterworth	32243034	n96075669	male						winner	American Academy of Arts and Letters	E. M. Forster Award	2007	no genre	career	10000.0	
 1073	Jim Crace	Jim	Crace	Q1563821	Jim Crace	66497143	n86145824	male						winner	American Academy of Arts and Letters	E. M. Forster Award	1996	no genre	career	10000.0	
 1073	Jim Crace	Jim	Crace	Q1563821	Jim Crace	66497143	n86145824	male						winner	Yale University	Windham Campbell Prize	2014	prose	career	165000.0	
 1074	Jim Grimsley	Jim	Grimsley	Q595717	Jim Grimsley	90608467	n94025802	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	2005	no genre	career	10000.0	
-1094	Joe Sacco	Joe	Sacco					male						winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2006	no genre	career	50000.0	
+1094	Joe Sacco	Joe	Sacco	Q335397	Joe Sacco	22277197	no95023135	male						winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2006	no genre	career	50000.0	
 1174	John A. Williams	John A. Williams	Williams	Q661925	John A. Williams	84582743	n50018058	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1962	no genre	career	10000.0	
-1101	John Ash	John	Ash					male						winner	Whiting Foundation	Whiting Award	1985	no genre	career	50000.0	
+1101	John Ash	John	Ash	Q4533369	John Ash	114340779	n82149366	male						winner	Whiting Foundation	Whiting Award	1985	no genre	career	50000.0	
 1107	John Berger	John	Berger	Q382604	John Berger	14766158	n79135220	male						winner	Lannan Foundation	Lannan Award	2002	no genre	career	200000.0	
 1107	John Berger	John	Berger	Q382604	John Berger	14766158	n79135220	male						winner	Lannan Foundation	Lannan Award	1989	prose	career	150000.0	
 1116	John Cheever	John	Cheever	Q336151	John Cheever	2468135	n78089819	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1956	no genre	career	10000.0	
@@ -4421,9 +4421,9 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1132	John Haines	John	Haines	Q6237237	John Haines	64131356	n50019759	male						winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2007	no genre	career	50000.0	
 1143	John Jeremiah Sullivan	John Jeremiah	Sullivan	Q6241824	John Jeremiah Sullivan	70761535	n2003012950	male						winner	Whiting Foundation	Whiting Award	2004	no genre	career	50000.0	
 1149	John Lanchester	John	Lanchester	Q1700782	John Lanchester	85382594	n95075558	male						winner	American Academy of Arts and Letters	E. M. Forster Award	2008	no genre	career	10000.0	
-1155	John McCormick	John	McCormick					male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1988	no genre	career	10000.0	
+1155	John McCormick	John	McCormick	Q61596826	John McCormick	86805	n92026691	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1988	no genre	career	10000.0	
 1156	John McGahern	John	McGahern	Q1277641	John McGahern	95152561	n80012547	male						winner	Lannan Foundation	Lannan Award	2003	prose	career	150000.0	
-1159	John Morris	John	Morris					male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1979	no genre	career	10000.0	
+1159	John Morris	John	Morris	Q6249481	John Morris	88072974	n50016844	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1979	no genre	career	10000.0	
 1160	John Murray	John	Murray					male						judge	New Literary Project (University of California, Berkeley and Lafayette Library)	Joyce Carol Oates Literary Prize/Simpson Family	2017	prose	career	50000.0	
 1161	John Neihardt	John	Neihardt	Q6250218	John Neihardt	59087102	n79081519	male						judge	Academy of American Poets	Academy of American Poets Fellowship	1967	poetry	career	25000.0	
 1161	John Neihardt	John	Neihardt	Q6250218	John Neihardt	59087102	n79081519	male						judge	Academy of American Poets	Academy of American Poets Fellowship	1966	poetry	career	25000.0	
@@ -4477,7 +4477,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1363	Lawrence Naumoff	Lawrence	Naumoff	Q6504413	Lawrence Naumoff	69645247	n87891897	male						winner	Whiting Foundation	Whiting Award	1990	no genre	career	50000.0	
 1374	Leon Edel	Leon	Edel	Q611518	Leon Edel	108589496	n79018725	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1959	no genre	career	10000.0	
 1381	Lerone Bennettjr	Lerone	Bennettjr					male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1978	no genre	career	10000.0	
-1397	Lin-Manuel Miranda	Lin-Manuel	Miranda					male						winner	American Academy of Arts and Letters	Arts and Letters Awards	2015	no genre	career	10000.0	
+1397	Lin-Manuel Miranda	Lin-Manuel	Miranda	Q1646482	Lin-Manuel Miranda	163147814	no2008101876	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	2015	no genre	career	10000.0	
 1407	Lionel Abel	Lionel	Abel	Q6555500	Lionel Abel	52597102	n82269687	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1964	no genre	career	10000.0	
 1425	Louis Edwards	Louis	Edwards	Q20888407	Louis Edwards	19752755	n90714501	male						winner	Whiting Foundation	Whiting Award	1994	no genre	career	50000.0	
 1430	Louis Untermeyer	Louis	Untermeyer	Q1872015	Louis Untermeyer	39541598	n79054344	male						winner	Library of Congress	Poet Laureate	1963	poetry	career	35000.0	
@@ -4518,7 +4518,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1820	Peter Cole	Peter	Cole	Q7173327	Peter Cole	51202798	n85274027	male						winner	MacArthur Foundation	MacArthur Fellowship	2007	no genre	career	500000.0	
 1829	Peter Reading	Peter	Reading	Q705197	Peter Reading	46859039	n50043930	male						winner	Lannan Foundation	Lannan Award	2004	poetry	career	150000.0	
 1830	Peter Schjeldahl	Peter	Schjeldahl	Q7176805	Peter Schjeldahl	24681003	n81028390	male						winner	American Academy of Arts and Letters	Harold D. Vursell Memorial Award	2010	prose	career	20000.0	
-1831	Peter Taylor	Peter	Taylor					male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1952	no genre	career	10000.0	
+1831	Peter Taylor	Peter	Taylor	Q7177265	Peter Taylor	110914595	n82057802	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1952	no genre	career	10000.0	
 1834	Peterde Vries	Peterde	Vries					male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1946	no genre	career	10000.0	
 1845	Philip Whalen	Philip	Whalen	Q2272795	Philip Whalen	54270610	n50014986	male						winner	American Academy of Arts and Letters	Morton Dauwen Zabel Award	1986	poetry	career	10000.0	
 1870	Randall Kenan	Randall	Kenan	Q3930018	Randall Kenan	49355658	n87852434	male						winner	Whiting Foundation	Whiting Award	1994	no genre	career	50000.0	
@@ -4526,10 +4526,10 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1875	Ray Bradbury	Ray	Bradbury	Q40640	Ray Bradbury	12305881	n79139258	male						winner	Tulsa Library Trust	Helmerich Distinguished Author Award	1994	prose	career	40000.0	
 1876	Raymond Abbott	Raymond	Abbott	Q7298539	Raymond Abbott	70291611	n82231436	male						winner	Whiting Foundation	Whiting Award	1985	no genre	career	50000.0	
 1893	Reynolds Price	Reynolds	Price	Q2619779	Reynolds Price	4970438	n79132486	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1971	no genre	career	10000.0	
-1896	Richard Blackmur	Richard	Blackmur					male						judge	Yale University	Bollingen Prize for Poetry	1958	poetry	career	10000.0	
-1896	Richard Blackmur	Richard	Blackmur					male						judge	Yale University	Bollingen Prize for Poetry	1957	poetry	career	10000.0	
-1898	Richard Chase	Richard	Chase					male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1953	no genre	career	10000.0	
-1909	Richard Nelson	Richard	Nelson					male						winner	American Academy of Arts and Letters	Arts and Letters Awards	2008	no genre	career	10000.0	
+1896	Richard Blackmur	Richard	Blackmur	Q1671208	R. P. Blackmur	76363565	n80013420	male						judge	Yale University	Bollingen Prize for Poetry	1958	poetry	career	10000.0	
+1896	Richard Blackmur	Richard	Blackmur	Q1671208	R. P. Blackmur	76363565	n80013420	male						judge	Yale University	Bollingen Prize for Poetry	1957	poetry	career	10000.0	
+1898	Richard Chase	Richard	Chase	Q6106938	J. Richard Chase			male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1953	no genre	career	10000.0	
+1909	Richard Nelson	Richard	Nelson	Q7328022	Richard Nelson	91090206	n80015792	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	2008	no genre	career	10000.0	
 1920	Richard Yates	Richard	Yates	Q544611	Richard Yates	17323284	n50014254	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1963	no genre	career	10000.0	
 1925	Rick Demarinis	Rick	Demarinis	Q204668	Rick DeMarinis	17221574	n85244651	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1990	no genre	career	10000.0	
 1929	Rick Rofihe	Rick	Rofihe	Q15438954	Rick Rofihe	11481761	n91037869	male						winner	Whiting Foundation	Whiting Award	1991	no genre	career	50000.0	
@@ -4563,7 +4563,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2061	Saïd Sayrafiezadeh	Saïd	Sayrafiezadeh	Q2212143	Saïd Sayrafiezadeh	43780697	n2013032106	male						winner	Whiting Foundation	Whiting Award	2010	no genre	career	50000.0	
 2046	Sam Shepard	Sam	Shepard	Q110400680	Sam Shepard			male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1974	no genre	career	10000.0	
 2060	Sanford Friedman	Sanford	Friedman	Q7417620	Sanford Friedman	57911331	n80057196	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1984	no genre	career	10000.0	
-2076	Scott McPherson	Scott	McPherson					male						winner	Whiting Foundation	Whiting Award	1991	no genre	career	50000.0	
+2076	Scott McPherson	Scott	McPherson	Q7436848	Scott McPherson	84256138	nr90028413	male						winner	Whiting Foundation	Whiting Award	1991	no genre	career	50000.0	
 2080	Seamus Heaney	Seamus	Heaney	Q93356	Seamus Heaney	109557338	n79099140	male						winner	American Academy of Arts and Letters	E. M. Forster Award	1975	no genre	career	10000.0	
 2082	Sean O'Brien	Sean	O'Brien	Q7441306	Sean O'Brien	69042526	n85006235	male						winner	American Academy of Arts and Letters	E. M. Forster Award	1993	no genre	career	10000.0	
 2097	Shelby Foote	Shelby	Foote	Q714250	Shelby Foote	71391025	n79058551	male						winner	Tulsa Library Trust	Helmerich Distinguished Author Award	2003	prose	career	40000.0	
@@ -4583,7 +4583,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2212	Theodore Dreiser	Theodore	Dreiser	Q486096	Theodore Dreiser	4944366	n79046644	male						winner	American Academy of Arts and Letters	Award of Merit Medal in the Novel	1944	prose	career	25000.0	
 2221	Thomas Keneally	Thomas	Keneally	Q298334	Thomas Keneally	41842145	n80034891	male						winner	Tulsa Library Trust	Helmerich Distinguished Author Award	2007	prose	career	40000.0	
 2225	Thomas Mann	Thomas	Mann	Q37030	Thomas Mann	54151065	n78095625	male						winner	American Academy of Arts and Letters	Award of Merit Medal in the Novel	1949	prose	career	25000.0	
-2232	Thomas Sancton	Thomas	Sancton	Q7793769	Thomas Sancton, Sr.			male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1944	no genre	career	10000.0	
+2232	Thomas Sancton	Thomas	Sancton					male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1944	no genre	career	10000.0	
 2250	Timothy Mo	Timothy	Mo	Q1392021	Timothy Mo	76339491	n78068180	male						winner	American Academy of Arts and Letters	E. M. Forster Award	1992	no genre	career	10000.0	
 2264	Tom McCarthy	Tom	McCarthy	Q430523	Tom McCarthy	84508554	n2010008229	male						winner	Yale University	Windham Campbell Prize	2013	prose	career	165000.0	
 2268	Tommy Pico	Tommy	Pico	Q53692241	Tommy Pico	159148207808700341328	no2016159728	male						winner	Whiting Foundation	Whiting Award	2018	no genre	career	50000.0	
@@ -4633,7 +4633,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2333	Wd Wetherell	Wd	Wetherell					male						winner	American Academy of Arts and Letters	Mildred And Harold Strauss Livings	1998	prose	career	100000.0	
 2346	Will Alexander	Will	Alexander	Q8002669	Will Alexander	41743649	nr97004801	male						winner	Poets & Writers	Jackson Poetry Prize	2016	poetry	career	75000.0	
 2348	Will Eno	Will	Eno	Q8002801	Will Eno	63512118	nb2001029214	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	2008	no genre	career	10000.0	
-2357	William Barrett	William	Barrett	Q2578657	William Emerson Barrett	38847928	n2008041752	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1988	no genre	career	10000.0	
+2357	William Barrett	William	Barrett	Q8005113	William Barrett			male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1988	no genre	career	10000.0	
 2365	William Humphrey	William	Humphrey	Q127079	William Humphrey	69404834	n50034158	male						winner	American Academy of Arts and Letters	Arts and Letters Awards	1963	no genre	career	10000.0	
 2367	William Kennedy	William	Kennedy	Q31984	William Kennedy	109902833	n50045355	male						winner	Tulsa Library Trust	Helmerich Distinguished Author Award	2001	prose	career	40000.0	
 2367	William Kennedy	William	Kennedy	Q31984	William Kennedy	109902833	n50045355	male						winner	MacArthur Foundation	MacArthur Fellowship	1983	no genre	career	500000.0	
@@ -4721,7 +4721,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 488	Danzy Senna	Danzy	Senna	Q5221478	Danzy Senna	92928559	n97076092	female	Stanford University	graduate	Univeristy of California, Irvine			judge	National Book Foundation	National Book Award	2019	prose	book	10000.0	Trust Excercise
 2166	Susan Choi	Susan	Choi	Q7647669	Susan Choi	80525953	n98008820	female	Yale University, Cornell University	graduate	Cornell University			winner	National Book Foundation	National Book Award	2019	prose	book	10000.0	Trust Excercise
 605	Dorothy Allison	Dorothy	Allison	Q275012	Dorothy Allison	100964772	n83313787	female		graduate				judge	National Book Foundation	National Book Award	2019	prose	book	10000.0	Trust Excercise
-159	Anne Sanow	Anne	Sanow					female		graduate	Washington University			winner	University of Pittsburg Press	Drue Heinz Literature Prize	2009	prose	book	15000.0	Triple Time
+159	Anne Sanow	Anne	Sanow			83491848	n2009017173	female		graduate	Washington University			winner	University of Pittsburg Press	Drue Heinz Literature Prize	2009	prose	book	15000.0	Triple Time
 149	Ann Patchett	Ann	Patchett	Q433485	Ann Patchett	54362733	n91108359	female		graduate	University of Iowa	1785		judge	University of Pittsburg Press	Drue Heinz Literature Prize	2009	prose	book	15000.0	Triple Time
 1232	Joy Williams	Joy	Williams	Q6297286	Joy Williams	17855227	n81082937	female		graduate	University of Iowa	233		judge	National Book Foundation	National Book Award	2007	prose	book	10000.0	Tree Of Smoke
 744	Francine Prose	Francine	Prose	Q2427599	Francine Prose	112469802	n50020196	female	Radcliffe College					judge	National Book Foundation	National Book Award	2007	prose	book	10000.0	Tree Of Smoke
@@ -4738,7 +4738,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1848	Phyllis McGinley	Phyllis	McGinley	Q7188601	Phyllis McGinley	114041772	n50007804	female						winner	Columbia University	Pulitzer Prize	1961	poetry	book	15000.0	Times Three: Selected Verse From Three Decades
 1703	Natasha Trethewey	Natasha	Trethewey	Q6968508	Natasha Trethewey	120068914	no00088459	female		graduate	University of Massachusetts, Amherst			judge	National Book Foundation	National Book Award	2007	poetry	book	10000.0	Time And Materials: Poems, 1997-2005
 1399	Linda Bierds	Linda	Bierds	Q6551409	Linda Bierds	56010	n85120347	female		graduate				judge	National Book Foundation	National Book Award	2007	poetry	book	10000.0	Time And Materials: Poems, 1997-2005
-23	Adrienne Brodeur	Adrienne	Brodeur	Q100281476	Adrienne Brodeur	72328655		female	Columbia University, University of Pennsylvania	graduate				judge	National Book Foundation	National Book Award	2002	prose	book	10000.0	Three Junes
+23	Adrienne Brodeur	Adrienne	Brodeur	Q100281476	Adrienne Brodeur	72328655	n00032725	female	Columbia University, University of Pennsylvania	graduate				judge	National Book Foundation	National Book Award	2002	prose	book	10000.0	Three Junes
 1240	Julia Glass	Julia	Glass	Q6306433	Julia Glass	120654826	n2001052456	female	Yale University					winner	National Book Foundation	National Book Award	2002	prose	book	10000.0	Three Junes
 954	Jacquelyn Mitchard	Jacquelyn	Mitchard	Q6120271	Jacquelyn Mitchard	41984519	n84073749	female						judge	National Book Foundation	National Book Award	2002	prose	book	10000.0	Three Junes
 1939	Rita Dove	Rita	Dove	Q445740	Rita Dove	39400140	n80111701	female		graduate	University of Iowa	966		winner	Columbia University	Pulitzer Prize	1987	poetry	book	15000.0	Thomas And Beula
@@ -4780,7 +4780,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 824	Gloria Naylor	Gloria	Naylor	Q3510225	Gloria Naylor	59679442	n81130505	female	Yale University	graduate				winner	National Book Foundation	National Book Award	1983	prose	book	10000.0	The Women Of Brewster Place
 262	Bonnie Costello	Bonnie	Costello	Q30069631	Bonnie Costello	27136022	n81014640	female	Cornell University	graduate				judge	Columbia University	Pulitzer Prize	1993	poetry	book	15000.0	The Wild Iris
 1437	Louise Gluck	Louise	Gluck	Q2344210	Louise Glück	84538845	n80005703	female						winner	Columbia University	Pulitzer Prize	1993	poetry	book	15000.0	The Wild Iris
-209	B. J. Chute	B. J.	Chute	Q55720440	Beatrice Joy Chute	30818536	n79089259	female						judge	National Book Foundation	National Book Award	1961	prose	book	10000.0	The Waters Of Kronos
+209	B. J. Chute	B. J.	Chute	Q5264686	Desmond Chute	67941313	n86016342	female						judge	National Book Foundation	National Book Award	1961	prose	book	10000.0	The Waters Of Kronos
 1677	Mrs William Johnson	Mrs William	Johnson					female						judge	National Book Foundation	National Book Award	1958	prose	book	10000.0	The Wapshot Chronicle
 678	Elizabeth Spencer	Elizabeth	Spencer	Q5363538	Elizabeth Spencer	108893360	n50021199	female		graduate				winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1957	prose	book	10000.0	The Voice At The Back Door
 1061	Jesmyn Ward	Jesmyn	Ward	Q3177574	Jesmyn Ward	48698155	n2008035038	female	Stanford University	graduate	University of Michigan		Stegner	judge	National Book Foundation	National Book Award	2016	prose	book	10000.0	The Underground Railroad
@@ -4796,7 +4796,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 368	Chase Twichell	Chase	Twichell	Q5087206	Chase Twichell	595149198244374940003	n81017543	female		graduate	University of Iowa	975		judge	Claremont Graduate University	Kate Tufts Discovery Award 	2015	poetry	book	10000.0	The Tribute Horse
 2133	Stephanie Burt	Stephanie	Burt	Q7608816	Stephanie Burt	34685160	n99832019	female	Harvard University, Yale University	graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	2015	poetry	book	10000.0	The Tribute Horse
 1268	Kate Gale	Kate	Gale	Q6375500	Kate Gale	60793358	n95057052	female		graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	2015	poetry	book	10000.0	The Tribute Horse
-2337	Wendy Martin	Wendy	Martin	Q20657280	Wednesday Martin	41322083	n2008083902	female		graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	2015	poetry	book	10000.0	The Tribute Horse
+2337	Wendy Martin	Wendy	Martin					female		graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	2015	poetry	book	10000.0	The Tribute Horse
 1352	Laura Kasischke	Laura	Kasischke	Q3218695	Laura Kasischke	41996793	n91073352	female		graduate	University of Michigan			judge	Academy of American Poets	Lenore Marshall Poetry Prize	2018	poetry	book	25000.0	The Trembling Answers
 1574	Mary Szybist	Mary	Szybist	Q6780804	Mary Szybist	9206280	n2002042294	female		graduate	University of Iowa	2270		judge	Academy of American Poets	Lenore Marshall Poetry Prize	2018	poetry	book	25000.0	The Trembling Answers
 1510	Marilyn Chin	Marilyn	Chin	Q6763512	Marilyn Chin	47840838	n88045226	female	Stanford University	graduate	University of Iowa	1276	Stegner	judge	Columbia University	Pulitzer Prize	2020	poetry	book	15000.0	The Tradition
@@ -4807,7 +4807,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2254	Tiphanie Yanique	Tiphanie	Yanique	Q16217661	Tiphanie Yanique	100819726	no2009151044	female		graduate	University of Houston			judge	Center for Fiction	First Novel Prize	2015	prose	book	15000.0	The Sympathizer
 2113	Siri Hustvedt	Siri	Hustvedt	Q259543	Siri Hustvedt	4998691	n87808224	female	Columbia University	graduate				judge	Center for Fiction	First Novel Prize	2015	prose	book	15000.0	The Sympathizer
 212	Barbara Bannon	Barbara	Bannon					female						judge	Columbia University	Pulitzer Prize	1979	prose	book	15000.0	The Stories Of John Cheever
-1693	Nancy Packer	Nancy	Packer	Q78760093	Nancy Huddleston Packer	65350792	n82070523	female	University of Chicago, Stanford University	graduate			Stegner	judge	Columbia University	Pulitzer Prize	1995	prose	book	15000.0	The Stone Diaries
+1693	Nancy Packer	Nancy	Packer					female	University of Chicago, Stanford University	graduate			Stegner	judge	Columbia University	Pulitzer Prize	1995	prose	book	15000.0	The Stone Diaries
 320	Carol Shields	Carol	Shields	Q259956	Carol Shields	4944537	n50024187	female		graduate				winner	Columbia University	Pulitzer Prize	1995	prose	book	15000.0	The Stone Diaries
 405	Claire Messud	Claire	Messud	Q529082	Claire Messud	119451282	n95012238	female	Yale University	graduate	Syracuse University			judge	Kirkus Review	Kirkus Prize	2016	prose	book	50000.0	The Sport Of Kings
 301	C. E. Morgan	C. E.	Morgan	Q5006091	C.E. Morgan	14238477	n2008022054	female	Harvard University	graduate				winner	Kirkus Review	Kirkus Prize	2016	prose	book	50000.0	The Sport Of Kings
@@ -4822,7 +4822,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2338	Wendy Steiner	Wendy	Steiner					female	Yale University	graduate				judge	National Book Foundation	National Book Award	1993	prose	book	10000.0	The Shipping News
 170	Annie Proulx	Annie	Proulx	Q229840	Annie Proulx	113957087	n80091138	female		graduate				winner	National Book Foundation	National Book Award	1993	prose	book	10000.0	The Shipping News
 170	Annie Proulx	Annie	Proulx	Q229840	Annie Proulx	113957087	n80091138	female		graduate				winner	Columbia University	Pulitzer Prize	1994	prose	book	15000.0	The Shipping News
-2179	Susan Wood	Susan	Wood	Q14949655	Susan Wood	24632806	n82203619	female		graduate				judge	National Book Foundation	National Book Award	1993	prose	book	10000.0	The Shipping News
+2179	Susan Wood	Susan	Wood	Q7648555	Susan Wood	20982141	n80068777	female		graduate				judge	National Book Foundation	National Book Award	1993	prose	book	10000.0	The Shipping News
 1849	Phyllis Rose	Phyllis	Rose	Q7188620	Phyllis Rose	54164888	n78008899	female						judge	National Book Foundation	National Book Award	1993	prose	book	10000.0	The Shipping News
 1678	Muriel Rukeyser	Muriel	Rukeyser	Q735177	Muriel Rukeyser	137544	n79034264	female	Columbia University					judge	National Book Foundation	National Book Award	1956	poetry	book	10000.0	The Shield Of Achilles
 1848	Phyllis McGinley	Phyllis	McGinley	Q7188601	Phyllis McGinley	114041772	n50007804	female						judge	National Book Foundation	National Book Award	1956	poetry	book	10000.0	The Shield Of Achilles
@@ -4833,14 +4833,14 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1436	Louise Erdrich	Louise	Erdrich	Q442679	Louise Erdrich	110425107	n83129937	female	Dartmouth College	graduate				winner	National Book Foundation	National Book Award	2012	prose	book	10000.0	The Round House
 2121	Stacey D'Erasmo	Stacey	D'Erasmo	Q7595824	Stacey D'Erasmo	19845036	n99038631	female	Barnard College, Stanford University	graduate			Stegner	judge	National Book Foundation	National Book Award	2012	prose	book	10000.0	The Round House
 777	Gail Caldwell	Gail	Caldwell	Q5517051	Gail Caldwell	78184914	n2005029467	female		graduate	University of Texas, Austin			judge	Columbia University	Pulitzer Prize	2007	prose	book	15000.0	The Road
-337	Catherine Stimpson	Catherine	Stimpson					female	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	2007	prose	book	15000.0	The Road
+337	Catherine Stimpson	Catherine	Stimpson	Q17433671	Catharine R. Stimpson	91932133	n80124711	female	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	2007	prose	book	15000.0	The Road
 327	Carolyn Forché	Carolyn	Forché	Q5045357	Carolyn Forché	2603438	n82066975	female		graduate	Bowling Green State University			judge	PEN America	Jean Stein Book Award	2017	no genre	book	75000.0	The Return: Fathers, Sons, And The Land In Between
 2115	Sonali Deraniyagala	Sonali	Deraniyagala	Q15999811	Sonali Deraniyagala	312567826		female		graduate				judge	PEN America	Jean Stein Book Award	2017	no genre	book	75000.0	The Return: Fathers, Sons, And The Land In Between
 563	Deborah Treisman	Deborah	Treisman					female						judge	PEN America	Jean Stein Book Award	2017	no genre	book	75000.0	The Return: Fathers, Sons, And The Land In Between
 900	Hisham Matar	Hisham	Matar	Q673985	Hisham Matar	87596371	n2006064193	female						winner	PEN America	Jean Stein Book Award	2017	no genre	book	75000.0	The Return: Fathers, Sons, And The Land In Between
-324	Caroline Kim	Caroline	Kim					female		graduate	University of Michigan			winner	University of Pittsburg Press	Drue Heinz Literature Prize	2020	prose	book	15000.0	The Prince Of Mournful Thoughts And Other Stories
+324	Caroline Kim	Caroline	Kim			575162664236255000594	no2021083253	female		graduate	University of Michigan			winner	University of Pittsburg Press	Drue Heinz Literature Prize	2020	prose	book	15000.0	The Prince Of Mournful Thoughts And Other Stories
 444	Cynthia Macdonald	Cynthia	Macdonald	Q5200115	Cynthia Macdonald	27098677	n79123602	female		graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	1980	poetry	book	25000.0	The Poems Of Stanley Kunitz, 1928-1978
-2252	Tina Hall	Tina	Hall					female		graduate	Bowling Green State University			winner	University of Pittsburg Press	Drue Heinz Literature Prize	2010	prose	book	15000.0	The Physics Of Imaginary Objects
+2252	Tina Hall	Tina	Hall			121077854	n2010031603	female		graduate	Bowling Green State University			winner	University of Pittsburg Press	Drue Heinz Literature Prize	2010	prose	book	15000.0	The Physics Of Imaginary Objects
 1889	Renata Adler	Renata	Adler	Q1567518	Renata Adler	76874608	n83210937	female	Harvard University	graduate				judge	University of Pittsburg Press	Drue Heinz Literature Prize	2010	prose	book	15000.0	The Physics Of Imaginary Objects
 1289	Katie Ford	Katie	Ford	Q6377439	Katie Ford			female	Harvard University	graduate	University of Iowa	3881		judge	National Book Foundation	National Book Award	2016	poetry	book	10000.0	The Performance Of Becoming Human
 1231	Joy Harjo	Joy	Harjo	Q292180	Joy Harjo	30693197	n81068743	female		graduate	University of Iowa	1077		judge	National Book Foundation	National Book Award	2016	poetry	book	10000.0	The Performance Of Becoming Human
@@ -4866,7 +4866,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1325	Kimiko Hahn	Kimiko	Hahn	Q1741639	Kimiko Hahn	21214011	n87930277	female	Columbia University	graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	2016	poetry	book	25000.0	The Nerve Of It: Poems New And Selected
 244	Betty Munger	Betty	Munger					female						judge	National Book Foundation	National Book Award	1981	poetry	book	10000.0	The Need To Hold Still: Poems
 1413	Lisel Mueller	Lisel	Mueller	Q6558751	Lisel Mueller	79075892	n79103777	female		graduate				winner	National Book Foundation	National Book Award	1981	poetry	book	10000.0	The Need To Hold Still: Poems
-2088	Shannon Cain	Shannon	Cain					female		graduate	Warren Wilson College			winner	University of Pittsburg Press	Drue Heinz Literature Prize	2011	prose	book	15000.0	The Necessity Of Certain Behaviors
+2088	Shannon Cain	Shannon	Cain			83611704	no2009042111	female		graduate	Warren Wilson College			winner	University of Pittsburg Press	Drue Heinz Literature Prize	2011	prose	book	15000.0	The Necessity Of Certain Behaviors
 75	Alice Mattison	Alice	Mattison	Q16204726	Alice Mattison	94297596	n82080489	female	Harvard University	graduate				judge	University of Pittsburg Press	Drue Heinz Literature Prize	2011	prose	book	15000.0	The Necessity Of Certain Behaviors
 328	Carolyn Kizer	Carolyn	Kizer	Q440064	Carolyn Kizer	18139398	n80159001	female	Columbia University	graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	1977	poetry	book	25000.0	The Names Of The Lost
 1031	Jean Stafford	Jean	Stafford	Q290633	Jean Stafford	109645819	n50053704	female						judge	National Book Foundation	National Book Award	1962	prose	book	10000.0	The Moviegoer
@@ -4877,10 +4877,10 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1557	Mary Colum	Mary	Colum	Q6779242	Mary Colum	12192381	nr94037574	female						judge	National Book Foundation	National Book Award	1950	prose	book	10000.0	The Man With The Golden Arm
 319	Carol Muske-Dukes	Carol	Muske-Dukes	Q5044485	Carol Muske-Dukes	92243860	n84041535	female		graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	1993	poetry	book	25000.0	The Man With Night Sweats
 577	Diane Johnson	Diane	Johnson	Q533343	Diane Johnson	44322506	n97094021	female						judge	Columbia University	Pulitzer Prize	1990	prose	book	15000.0	The Mambo Kings Play Songs Of Love
-77	Alice Morris	Alice	Morris					female						judge	National Book Foundation	National Book Award	1959	prose	book	10000.0	The Magic Barrel
+77	Alice Morris	Alice	Morris	Q111744519	Alice S. Morris			female						judge	National Book Foundation	National Book Award	1959	prose	book	10000.0	The Magic Barrel
 1028	Jayne Anne Phillips	Jayne Anne	Phillips	Q4353602	Jayne Anne Phillips	44274409	n79033346	female		graduate	University of Iowa	1109		judge	PEN America	Hemingway Award for Debut Novel	2011	prose	book	10000.0	The Madonnas Of Echo Park
 91	Allegra Goodman	Allegra	Goodman	Q4731395	Allegra Goodman	97858346	n88276066	female	Harvard University, Stanford University	graduate			Stegner	judge	PEN America	Hemingway Award for Debut Novel	2011	prose	book	10000.0	The Madonnas Of Echo Park
-1233	Joyce Carol Oates	Joyce Carol	Oates	Q217557	Joyce Carol Oates	7662418	n78095538	female		graduate				judge	University of Pittsburg Press	Drue Heinz Literature Prize	1984	prose	book	15000.0	The Luckiest Man In The World
+1233	Joyce Carol Oates	Joyce Carol	Oates	Q217557	Joyce Carol Oates	7662418	n87851370	female		graduate				judge	University of Pittsburg Press	Drue Heinz Literature Prize	1984	prose	book	15000.0	The Luckiest Man In The World
 1222	Josephine Herbst	Josephine	Herbst	Q6288380	Josephine Herbst	93008242	n50068741	female						judge	National Book Foundation	National Book Award	1968	poetry	book	10000.0	The Light Around The Body
 1410	Lisa Ko	Lisa	Ko	Q38093438	Lisa Ko	349147905374479092994	no2016136252	female		graduate	City College of New York			winner	PEN America	Bellwether Prize for Socially Engaged Fiction	2016	prose	book	25000.0	The Leavers
 1288	Kathy Pories	Kathy	Pories					female		graduate				judge	PEN America	Bellwether Prize for Socially Engaged Fiction	2016	prose	book	25000.0	The Leavers
@@ -4912,9 +4912,9 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1809	Pearl Buck	Pearl	Buck	Q80900	Pearl S. Buck	91868694	n79026662	female						winner	Columbia University	Pulitzer Prize	1932	prose	book	15000.0	The Good Earth
 2040	Sabina Murray	Sabina	Murray	Q7396119	Sabina Murray	195198517	n93068037	female		graduate				judge	Columbia University	Pulitzer Prize	2014	prose	book	15000.0	The Goldfinch
 599	Donna Tartt	Donna	Tartt	Q255339	Donna Tartt	85733536	n92103807	female						winner	Columbia University	Pulitzer Prize	2014	prose	book	15000.0	The Goldfinch
-135	Angela Morales	Angela	Morales					female		graduate	University of Iowa	missing		winner	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	2017	prose	book	15000.0	The Girls In My Town: Essays
+135	Angela Morales	Angela	Morales	Q29912453		139145542429496640126	no2011198440	female		graduate	University of Iowa	missing		winner	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	2017	prose	book	15000.0	The Girls In My Town: Essays
 724	Eula Biss	Eula	Biss	Q5408712	Eula Biss	43807127	nb2002044713	female		graduate	University of Iowa	missing		judge	PEN America	Diamonstein-Spielvogel Award for the Art of the Essay	2017	prose	book	15000.0	The Girls In My Town: Essays
-871	Heidi Durrow	Heidi	Durrow					female	Stanford University, Columbia University	graduate				winner	PEN America	Bellwether Prize for Socially Engaged Fiction	2008	prose	book	25000.0	The Girl Who Fell From The Sky
+871	Heidi Durrow	Heidi	Durrow	Q5699003		91039810	n2009042855	female	Stanford University, Columbia University	graduate				winner	PEN America	Bellwether Prize for Socially Engaged Fiction	2008	prose	book	25000.0	The Girl Who Fell From The Sky
 373	Chinelo Okparanta	Chinelo	Okparanta	Q16733667	Chinelo Okparanta	304250452	n2013040834	female		graduate	University of Iowa	missing		judge	National Book Foundation	National Book Award	2018	prose	book	10000.0	The Friend
 1659	Min Jin Lee	Min Jin	Lee	Q13563026	Min Jin Lee	1903619	n2006086697	female	Yale University	graduate	Georgetown University			judge	National Book Foundation	National Book Award	2018	prose	book	10000.0	The Friend
 2107	Sigrid Nunez	Sigrid	Nunez	Q7513133	Sigrid Nunez	27280224	n94067451	female	Barnard College, Columbia University	graduate	Columbia University			winner	National Book Foundation	National Book Award	2018	prose	book	10000.0	The Friend
@@ -5019,9 +5019,9 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 240	Beth Bachmann	Beth	Bachmann	Q4897443	Beth Bachmann	101502413	no2009161802	female		graduate				winner	Claremont Graduate University	Kate Tufts Discovery Award 	2010	poetry	book	10000.0	Temper
 1268	Kate Gale	Kate	Gale	Q6375500	Kate Gale	60793358	n95057052	female		graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	2010	poetry	book	10000.0	Temper
 607	Dorothy Fisher	Dorothy	Fisher	Q5298346	Dorothy Canfield Fisher	34577709	n50005248	female	Cornell University	graduate				judge	Columbia University	Pulitzer Prize	1941	prose	book	15000.0	Sunderland Capture
-1351	Laura Hendrie	Laura	Hendrie					female						winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1995	prose	book	10000.0	Stygo
+1351	Laura Hendrie	Laura	Hendrie	Q94663913		28754211	n94002148	female						winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1995	prose	book	10000.0	Stygo
 859	Harriet Doerr	Harriet	Doerr	Q5664087	Harriet Doerr	84475099	n83186402	female						winner	National Book Foundation	National Book Award	1984	prose	book	10000.0	Stones For Ibarra
-2180	Susanna Daniel	Susanna	Daniel					female	Columbia University	graduate	University of Iowa	2496		winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2011	prose	book	25000.0	Stiltsville
+2180	Susanna Daniel	Susanna	Daniel			48584397	n2002029143	female	Columbia University	graduate	University of Iowa	2496		winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2011	prose	book	25000.0	Stiltsville
 2400	Yiyun Li	Yiyun	Li	Q460088	Yiyun Li	66761360	n2004151571	female		graduate	University of Iowa	4032		judge	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2011	prose	book	25000.0	Stiltsville
 2165	Susan Cheever	Susan	Cheever	Q7647665	Susan Cheever	64022423	n79083655	female	Brown University					judge	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2011	prose	book	25000.0	Stiltsville
 1235	Judith Ortiz Cofer	Judith Ortiz	Cofer	Q6303597	Judith Ortiz Cofer	115049765	n87943894	female		graduate				judge	Academy of American Poets	Lenore Marshall Poetry Prize	2003	poetry	book	25000.0	Still Life With Waterfall
@@ -5046,7 +5046,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 162	Anne Tyler	Anne	Tyler	Q235615	Anne Tyler	39384885	n79100453	female						judge	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2018	prose	book	10000.0	Sonora
 1463	Lynne Sharon Schwartz	Lynne Sharon	Schwartz	Q1878899	Lynne Sharon Schwartz	49379687	n80017432	female		graduate	University of Iowa	3674		judge	PEN America	Faulkner Award for Fiction	1987	prose	book	15000.0	Soldiers In Hiding
 632	Edna Ferber	Edna	Ferber	Q283496	Edna Ferber	32079532	n79077439	female						winner	Columbia University	Pulitzer Prize	1925	prose	book	15000.0	So Big
-1372	Lee Smith	Lee	Smith	Q13563113	Lee Smith	54950342	n80070525	female						judge	PEN America	Faulkner Award for Fiction	1995	prose	book	15000.0	Snow Falling On Cedars
+1372	Lee Smith	Lee	Smith	Q6515097	Lee Smith	83499931	n2009018497	female						judge	PEN America	Faulkner Award for Fiction	1995	prose	book	15000.0	Snow Falling On Cedars
 140	Ann Arsensberg	Ann	Arsensberg					female	Radcliffe College, Harvard University	graduate				winner	National Book Foundation	National Book Award	1981	prose	book	10000.0	Sister Wolf
 1061	Jesmyn Ward	Jesmyn	Ward	Q3177574	Jesmyn Ward	48698155	n2008035038	female	Stanford University	graduate	University of Michigan		Stegner	winner	National Book Foundation	National Book Award	2017	prose	book	10000.0	Sing, Unburied, Sing
 1264	Karolina Waclawiak	Karolina	Waclawiak					female	Columbia University	graduate				judge	National Book Foundation	National Book Award	2017	prose	book	10000.0	Sing, Unburied, Sing
@@ -5092,7 +5092,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 565	Deirdre McNamer	Deirdre	McNamer	Q5252576	Deirdre McNamer			female		graduate	University of Montana			judge	National Book Foundation	National Book Award	2011	prose	book	10000.0	Salvage The Bones
 1061	Jesmyn Ward	Jesmyn	Ward	Q3177574	Jesmyn Ward	48698155	n2008035038	female	Stanford University	graduate	University of Michigan		Stegner	winner	National Book Foundation	National Book Award	2011	prose	book	10000.0	Salvage The Bones
 2400	Yiyun Li	Yiyun	Li	Q460088	Yiyun Li	66761360	n2004151571	female		graduate	University of Iowa	4032		judge	National Book Foundation	National Book Award	2011	prose	book	10000.0	Salvage The Bones
-423	Colleen McElroy	Colleen	McElroy					female		graduate				judge	National Book Foundation	National Book Award	1995	prose	book	10000.0	Sabbath's Theater
+423	Colleen McElroy	Colleen	McElroy	Q5146261	Colleen J. McElroy	92160010	n80115597	female		graduate				judge	National Book Foundation	National Book Award	1995	prose	book	10000.0	Sabbath's Theater
 707	Erica Jong	Erica	Jong	Q236950	Erica Jong	108237346	n80046407	female	Barnard College					judge	National Book Foundation	National Book Award	1995	prose	book	10000.0	Sabbath's Theater
 558	Deborah Digges	Deborah	Digges	Q2408618	Deborah Digges	40815137	n85177797	female		graduate	University of Iowa	1592		winner	Claremont Graduate University	Kingsley Tufts Poetry Award	1996	poetry	book	100000.0	Rough Music
 80	Alice Quinn	Alice	Quinn	Q62129862	Alice Quinn	6145424144586790350	n2020000560	female						judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1996	poetry	book	100000.0	Rough Music
@@ -5114,7 +5114,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1268	Kate Gale	Kate	Gale	Q6375500	Kate Gale	60793358	n95057052	female		graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	2012	poetry	book	10000.0	Radial Symmetry
 80	Alice Quinn	Alice	Quinn	Q62129862	Alice Quinn	6145424144586790350	n2020000560	female						judge	National Book Foundation	National Book Award	1982	prose	book	10000.0	Rabbit Is Rich & So Long, See You Tomorrow
 80	Alice Quinn	Alice	Quinn	Q62129862	Alice Quinn	6145424144586790350	n2020000560	female						judge	National Book Foundation	National Book Award	1982	prose	book	10000.0	Rabbit Is Rich & So Long, See You Tomorrow
-1492	Margaret Manning	Margaret	Manning					female						judge	Columbia University	Pulitzer Prize	1982	prose	book	15000.0	Rabbit Is Rich
+1492	Margaret Manning	Margaret	Manning	Q19561358	Margaret R. Manning			female						judge	Columbia University	Pulitzer Prize	1982	prose	book	15000.0	Rabbit Is Rich
 162	Anne Tyler	Anne	Tyler	Q235615	Anne Tyler	39384885	n79100453	female						judge	Columbia University	Pulitzer Prize	1991	prose	book	15000.0	Rabbit At Rest
 368	Chase Twichell	Chase	Twichell	Q5087206	Chase Twichell	595149198244374940003	n81017543	female		graduate	University of Iowa	975		judge	Academy of American Poets	Lenore Marshall Poetry Prize	1998	poetry	book	25000.0	Questions For Ecclesiastes
 25	Adrienne Rich	Adrienne	Rich	Q270705	Adrienne Rich	16565	no2010203172	female	Radcliffe College	graduate				judge	National Book Foundation	National Book Award	1958	poetry	book	10000.0	Promises: Poems, 1954-1956
@@ -5133,7 +5133,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1378	Leonie Adams	Leonie	Adams	Q467163	Léonie Adams	114359194	n81117461	female	Barnard College					judge	National Book Foundation	National Book Award	1962	poetry	book	10000.0	Poems (Vol 1 of Seven)
 1011	Janet Kauffman	Janet	Kauffman	Q6153426	Janet Kauffman	94916678	n82014994	female	University of Chicago	graduate				winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1985	prose	book	10000.0	Places In The World A Woman Could Walk
 249	Bharati Mukherjee	Bharati	Mukherjee	Q4357833	Bharati Mukherjee	76348204	n50004570	female		graduate	University of Iowa	171		judge	PEN America	Faulkner Award for Fiction	1991	prose	book	15000.0	Philadelphia Fire
-1592	Maureen Howard,	Maureen	Howard,					female						judge	PEN America	Faulkner Award for Fiction	1991	prose	book	15000.0	Philadelphia Fire
+1592	Maureen Howard,	Maureen	Howard,	Q6792696	Maureen Howard	30439573	n79147912	female						judge	PEN America	Faulkner Award for Fiction	1991	prose	book	15000.0	Philadelphia Fire
 2092	Sharon Olds	Sharon	Olds	Q3180469	Sharon Olds	13382047	n79125390	female	Stanford University, Columbia University	graduate				judge	National Book Foundation	National Book Award	1995	poetry	book	10000.0	Passing Through: The Later Poems, New And Selected
 2058	Sandra McPherson	Sandra	McPherson	Q7416709	Sandra McPherson	72717074	n81082863	female						judge	National Book Foundation	National Book Award	1995	poetry	book	10000.0	Passing Through: The Later Poems, New And Selected
 83	Alicia Ostriker	Alicia	Ostriker	Q21623	Alicia Ostriker	79060171	n80139339	female		graduate				judge	Columbia University	Pulitzer Prize	1988	poetry	book	15000.0	Partial Accounts: New And Selected Poems
@@ -5267,17 +5267,17 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1694	Nancy Pearl	Nancy	Pearl	Q6962909	Nancy Pearl	75645081	n99027581	female		graduate				judge	Columbia University	Pulitzer Prize	2018	prose	book	15000.0	Less
 414	Claudia Emerson	Claudia	Emerson	Q5129165	Claudia Emerson	92855410	n97014073	female		graduate	University of North Carolina			winner	Columbia University	Pulitzer Prize	2006	poetry	book	15000.0	Late Wife
 1562	Mary Karr	Mary	Karr	Q1598388	Mary Karr	94096111	n85249942	female		graduate	Goddard College			judge	Columbia University	Pulitzer Prize	2006	poetry	book	15000.0	Late Wife
-1658	Mimi Lok	Mimi	Lok	Q94839375	Mimi Lok	35157581634433781083		female		graduate	San Francisco State University			winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2020	prose	book	10000.0	Last Of Her Name
+1658	Mimi Lok	Mimi	Lok	Q94839375	Mimi Lok	35157581634433781083	no2019179301	female		graduate	San Francisco State University			winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2020	prose	book	10000.0	Last Of Her Name
 1232	Joy Williams	Joy	Williams	Q6297286	Joy Williams	17855227	n81082937	female		graduate	University of Iowa	233		judge	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2015	prose	book	10000.0	Land Of Love And Drowning
 2254	Tiphanie Yanique	Tiphanie	Yanique	Q16217661	Tiphanie Yanique	100819726	no2009151044	female		graduate	University of Houston			winner	Center for Fiction	First Novel Prize	2014	prose	book	15000.0	Land Of Love And Drowning
 2254	Tiphanie Yanique	Tiphanie	Yanique	Q16217661	Tiphanie Yanique	100819726	no2009151044	female		graduate	University of Houston			winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2015	prose	book	10000.0	Land Of Love And Drowning
-1481	Malika Booker	Malika	Booker	Q29961024	Malika Booker	309792400		female						judge	Center for Fiction	First Novel Prize	2014	prose	book	15000.0	Land Of Love And Drowning
-325	Caroline Miller	Caroline	Miller					female						winner	Columbia University	Pulitzer Prize	1934	prose	book	15000.0	Lamb In His Bosom
+1481	Malika Booker	Malika	Booker	Q29961024	Malika Booker	309792400	no2009071666	female						judge	Center for Fiction	First Novel Prize	2014	prose	book	15000.0	Land Of Love And Drowning
+325	Caroline Miller	Caroline	Miller	Q5045187		77583089	n79021980	female						winner	Columbia University	Pulitzer Prize	1934	prose	book	15000.0	Lamb In His Bosom
 253	Binnie Kirshenbaum	Binnie	Kirshenbaum	Q4914441	Binnie Kirshenbaum	10023772	n88166821	female	Columbia University	graduate	Brooklyn College			judge	Center for Fiction	First Novel Prize	2011	prose	book	15000.0	Lamb
 1396	Lily Tuck	Lily	Tuck	Q1245105	Lily Tuck	114951829	n90651580	female	Radcliffe College	graduate				judge	Center for Fiction	First Novel Prize	2011	prose	book	15000.0	Lamb
 438	Cristina García	Cristina	García	Q5186349	Cristina García	46837851	n92051709	female	Barnard College	graduate				judge	Center for Fiction	First Novel Prize	2011	prose	book	15000.0	Lamb
 263	Bonnie Nadzam	Bonnie	Nadzam	Q28839713	Bonnie Nadzam			female		graduate				winner	Center for Fiction	First Novel Prize	2011	prose	book	15000.0	Lamb
-598	Donna Gershten	Donna	Gershten	Q5296356	Donna Gershten	51910764		female		graduate	Warren Wilson College			winner	PEN America	Bellwether Prize for Socially Engaged Fiction	2000	prose	book	25000.0	Kissing The Virgin's Mouth
+598	Donna Gershten	Donna	Gershten	Q5296356	Donna Gershten	51910764	n00041492	female		graduate	Warren Wilson College			winner	PEN America	Bellwether Prize for Socially Engaged Fiction	2000	prose	book	25000.0	Kissing The Virgin's Mouth
 1566	Mary McCarthy	Mary	McCarthy	Q268147	Mary McCarthy	94457792	n79060089	female						judge	National Book Foundation	National Book Award	1976	prose	book	10000.0	J R
 1596	Maurya Simon	Maurya	Simon	Q28124160	Maurya Simon	40839083	n85362155	female		graduate	Univeristy of California, Irvine			judge	Claremont Graduate University	Kate Tufts Discovery Award 	2001	poetry	book	10000.0	Invisible Tender
 1046	Jennifer Clarvoe	Jennifer	Clarvoe	Q6178207	Jennifer Clarvoe	70159159	n00031209	female	Princeton University	graduate				winner	Claremont Graduate University	Kate Tufts Discovery Award 	2001	poetry	book	10000.0	Invisible Tender
@@ -5315,7 +5315,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 602	Dorianne Laux	Dorianne	Laux	Q5297809	Dorianne Laux	164569864	n85274151	female						judge	National Book Foundation	National Book Award	2002	poetry	book	10000.0	In The Next Galaxy
 689	Ellen Hunnicutt	Ellen	Hunnicutt	Q5364885	Ellen Hunnicutt	16219118	n85275895	female		graduate				winner	University of Pittsburg Press	Drue Heinz Literature Prize	1987	prose	book	15000.0	In The Music Library
 1686	Nadine Gordimer	Nadine	Gordimer	Q47619	Nadine Gordimer	86692340	n80037754	female						judge	University of Pittsburg Press	Drue Heinz Literature Prize	1987	prose	book	15000.0	In The Music Library
-18	Adria Bernardi	Adria	Bernardi					female	University of Chicago	graduate				winner	University of Pittsburg Press	Drue Heinz Literature Prize	2000	prose	book	15000.0	In The Gathering Woods
+18	Adria Bernardi	Adria	Bernardi	Q4684766		28637279	n88245294	female	University of Chicago	graduate				winner	University of Pittsburg Press	Drue Heinz Literature Prize	2000	prose	book	15000.0	In The Gathering Woods
 674	Elizabeth McCracken	Elizabeth	McCracken	Q5363184	Elizabeth McCracken	17365134	n92111648	female		graduate	University of Iowa	2016		judge	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2016	prose	book	25000.0	In The Country: Stories
 624	Edie Meidav	Edie	Meidav	Q5338028	Edie Meidav	84511476	n00043661	female	Yale University	graduate	Mills College			judge	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2016	prose	book	25000.0	In The Country: Stories
 1622	Mia Alvar	Mia	Alvar	Q23816413	Mia Alvar	310711634	n2014058734	female	Harvard University, Columbia University	graduate	Columbia University			winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2016	prose	book	25000.0	In The Country: Stories
@@ -5389,7 +5389,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1699	Natalie Diaz	Natalie	Diaz	Q16974419	Natalie Diaz	227752265	n2012003417	female		graduate	Old Dominion University			judge	PEN America	Jean Stein Book Award	2019	no genre	book	75000.0	Friday Black 
 274	Brenda Shaughnessy	Brenda	Shaughnessy	Q4960761	Brenda Shaughnessy	60865268	n98097930	female	Columbia University	graduate	Columbia University			judge	PEN America	Jean Stein Book Award	2019	no genre	book	75000.0	Friday Black 
 1047	Jennifer Clement	Jennifer	Clement	Q15456399	Jennifer Clement	69146854	no94043719	female	Princeton University	graduate				judge	PEN America	Jean Stein Book Award	2019	no genre	book	75000.0	Friday Black 
-874	Heidy Steidlmayer	Heidy	Steidlmayer					female		graduate	Warren Wilson College			winner	Claremont Graduate University	Kate Tufts Discovery Award 	2013	poetry	book	10000.0	Fowling Piece
+874	Heidy Steidlmayer	Heidy	Steidlmayer			170370658	n2011024643	female		graduate	Warren Wilson College			winner	Claremont Graduate University	Kate Tufts Discovery Award 	2013	poetry	book	10000.0	Fowling Piece
 1401	Linda Gregerson	Linda	Gregerson	Q6551613	Linda Gregerson	29682677	n83187938	female	Stanford University	graduate	University of Iowa	1007		judge	Claremont Graduate University	Kate Tufts Discovery Award 	2013	poetry	book	10000.0	Fowling Piece
 1268	Kate Gale	Kate	Gale	Q6375500	Kate Gale	60793358	n95057052	female		graduate				judge	Claremont Graduate University	Kate Tufts Discovery Award 	2013	poetry	book	10000.0	Fowling Piece
 1353	Laura Lippman	Laura	Lippman	Q446483	Laura Lippman	85629402	n00036081	female						judge	National Book Foundation	National Book Award	2015	prose	book	10000.0	Fortune Smiles
@@ -5409,7 +5409,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 877	Helen Vendler	Helen	Vendler	Q5703331	Helen Vendler	108450526	n79095151	female	Harvard University	graduate				judge	PEN America	Diamonstein-Spielvogel Award For The Art Of The Essay	1997	prose	book	15000.0	Fame And Folly: Essays
 445	Cynthia Ozick	Cynthia	Ozick	Q444849	Cynthia Ozick	110575264	n80046659	female		graduate				winner	PEN America	Diamonstein-Spielvogel Award For The Art Of The Essay	1997	prose	book	15000.0	Fame And Folly: Essays
 80	Alice Quinn	Alice	Quinn	Q62129862	Alice Quinn	6145424144586790350	n2020000560	female						judge	Claremont Graduate University	Kingsley Tufts Poetry Award	1998	poetry	book	100000.0	Falling Water
-1763	Paisley Rekdal	Paisley	Rekdal	Q16734027	Paisley Rekdal	50453554		female		graduate	University of Michigan			judge	National Book Foundation	National Book Award	2014	poetry	book	10000.0	Faithful And Virtuous Night
+1763	Paisley Rekdal	Paisley	Rekdal	Q16734027	Paisley Rekdal	50453554	n00021042	female		graduate	University of Michigan			judge	National Book Foundation	National Book Award	2014	poetry	book	10000.0	Faithful And Virtuous Night
 1291	Katie Peterson	Katie	Peterson					female	Stanford University, Harvard University	graduate			Stegner	judge	National Book Foundation	National Book Award	2014	poetry	book	10000.0	Faithful And Virtuous Night
 649	Eileen Myles	Eileen	Myles	Q5349419	Eileen Myles	61680324	n80082959	female						judge	National Book Foundation	National Book Award	2014	poetry	book	10000.0	Faithful And Virtuous Night
 1437	Louise Gluck	Louise	Gluck	Q2344210	Louise Glück	84538845	n80005703	female						winner	National Book Foundation	National Book Award	2014	poetry	book	10000.0	Faithful And Virtuous Night
@@ -5419,7 +5419,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1714	Nelly Rosario	Nelly	Rosario					female	Columbia University	graduate	Columbia University			judge	PEN America	Faulkner Award for Fiction	2013	prose	book	15000.0	Everything Begins & Ends At The Kentucky Club
 4	A. J. Verdelle	A. J.	Verdelle	Q4647222	A.J. Verdelle	92332396	n94104334	female	University of Chicago	graduate	Bard College			judge	PEN America	Faulkner Award for Fiction	2013	prose	book	15000.0	Everything Begins & Ends At The Kentucky Club
 564	Debra Magpie Earling	Debra Magpie	Earling	Q5248490	Debra Magpie Earling	19919959	n2001026836	female	Cornell University	graduate	Cornell University			judge	PEN America	Faulkner Award for Fiction	2007	prose	book	15000.0	Everyman
-1015	Janice Harrington	Janice	Harrington					female						winner	Claremont Graduate University	Kate Tufts Discovery Award 	2008	poetry	book	10000.0	Even The Hollow My Body Made Is Gone
+1015	Janice Harrington	Janice	Harrington	Q6154314		78007342	n94040410	female						winner	Claremont Graduate University	Kate Tufts Discovery Award 	2008	poetry	book	10000.0	Even The Hollow My Body Made Is Gone
 97	Allison Joseph	Allison	Joseph	Q4732772	Allison Joseph	16439070	n93052330	female		graduate	Indiana University			judge	Claremont Graduate University	Kate Tufts Discovery Award 	2008	poetry	book	10000.0	Even The Hollow My Body Made Is Gone
 80	Alice Quinn	Alice	Quinn	Q62129862	Alice Quinn	6145424144586790350	n2020000560	female						judge	Claremont Graduate University	Kate Tufts Discovery Award 	2008	poetry	book	10000.0	Even The Hollow My Body Made Is Gone
 438	Cristina García	Cristina	García	Q5186349	Cristina García	46837851	n92051709	female	Barnard College	graduate				judge	National Book Foundation	National Book Award	2005	prose	book	10000.0	Europe Central
@@ -5435,27 +5435,27 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2133	Stephanie Burt	Stephanie	Burt	Q7608816	Stephanie Burt	34685160	n99832019	female	Harvard University, Yale University	graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2015	poetry	book	100000.0	Enchantèe
 137	Angie Estes	Angie	Estes	Q4763200	Angie Estes	65673325	n92119100	female		graduate				winner	Claremont Graduate University	Kingsley Tufts Poetry Award	2015	poetry	book	100000.0	Enchantèe
 1268	Kate Gale	Kate	Gale	Q6375500	Kate Gale	60793358	n95057052	female		graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2015	poetry	book	100000.0	Enchantèe
-2337	Wendy Martin	Wendy	Martin	Q20657280	Wednesday Martin	41322083	n2008083902	female		graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2015	poetry	book	100000.0	Enchantèe
-1693	Nancy Packer	Nancy	Packer	Q78760093	Nancy Huddleston Packer	65350792	n82070523	female	University of Chicago, Stanford University	graduate			Stegner	judge	Columbia University	Pulitzer Prize	2002	prose	book	15000.0	Empire Falls
+2337	Wendy Martin	Wendy	Martin					female		graduate				judge	Claremont Graduate University	Kingsley Tufts Poetry Award	2015	poetry	book	100000.0	Enchantèe
+1693	Nancy Packer	Nancy	Packer					female	University of Chicago, Stanford University	graduate			Stegner	judge	Columbia University	Pulitzer Prize	2002	prose	book	15000.0	Empire Falls
 2400	Yiyun Li	Yiyun	Li	Q460088	Yiyun Li	66761360	n2004151571	female		graduate	University of Iowa	4032		judge	PEN America	Hemingway Award for Debut Novel	2015	prose	book	10000.0	Elegy On Kinderklavier
-1492	Margaret Manning	Margaret	Manning					female						judge	Columbia University	Pulitzer Prize	1978	prose	book	15000.0	Elbow Room
+1492	Margaret Manning	Margaret	Manning	Q19561358	Margaret R. Manning			female						judge	Columbia University	Pulitzer Prize	1978	prose	book	15000.0	Elbow Room
 1758	Ottessa Moshfegh	Ottessa	Moshfegh	Q20707944	Ottessa Moshfegh	313296794	no2014170355	female	Barnard College, Brown University, Stanford University	graduate	Brown University		Stegner	winner	PEN America	Hemingway Award for Debut Novel	2016	prose	book	10000.0	Eileen
 65	Alexandra Marshall	Alexandra	Marshall					female	Columbia University	graduate				judge	PEN America	Hemingway Award for Debut Novel	2016	prose	book	10000.0	Eileen
 2015	Rosanna Warren	Rosanna	Warren	Q7367344	Rosanna Warren	64050468	n84089568	female	Yale University	graduate	Johns Hopkins University			judge	National Book Foundation	National Book Award	1997	poetry	book	10000.0	Effort At Speech: New And Selected Poems
 1751	Olympia Vernon	Olympia	Vernon	Q7088985	Olympia Vernon	65829454	n2002039899	female		graduate	Louisiana State University			winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2004	prose	book	10000.0	Eden
 462	Dana Spiotta	Dana	Spiotta	Q5214834	Dana Spiotta	14113343	n2001028888	female						winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2007	prose	book	10000.0	Eat The Document
-333	Catharine Stimpson	Catharine	Stimpson					female	Columbia University	graduate				judge	National Book Foundation	National Book Award	1985	prose	book	10000.0	Easy In The Islands & White Noise
+333	Catharine Stimpson	Catharine	Stimpson	Q17433671	Catharine R. Stimpson	91932133	n80124711	female	Columbia University	graduate				judge	National Book Foundation	National Book Award	1985	prose	book	10000.0	Easy In The Islands & White Noise
 577	Diane Johnson	Diane	Johnson	Q533343	Diane Johnson	44322506	n97094021	female						judge	National Book Foundation	National Book Award	1985	prose	book	10000.0	Easy In The Islands & White Noise
 577	Diane Johnson	Diane	Johnson	Q533343	Diane Johnson	44322506	n97094021	female						judge	National Book Foundation	National Book Award	1985	prose	book	10000.0	Easy In The Islands & White Noise
 1517	Marita Golden	Marita	Golden	Q6765743	Marita Golden	79059792	n82088043	female	Columbia University	graduate				judge	PEN America	Faulkner Award for Fiction	1989	prose	book	15000.0	Dusk
 1080	Joan Chase	Joan	Chase	Q6204941	Joan Chase	79052983	n82162353	female						winner	PEN America	Hemingway Award for Debut Novel	1984	prose	book	10000.0	During The Reign Of The Queen Of Persia
 1659	Min Jin Lee	Min Jin	Lee	Q13563026	Min Jin Lee	1903619	n2006086697	female	Yale University	graduate	Georgetown University			judge	University of Pittsburg Press	Drue Heinz Literature Prize	2019	prose	book	15000.0	Driving In Cars With Homeless Men
-1272	Kate Wisel	Kate	Wisel					female		graduate	Columba College			winner	University of Pittsburg Press	Drue Heinz Literature Prize	2019	prose	book	15000.0	Driving In Cars With Homeless Men
+1272	Kate Wisel	Kate	Wisel			40157581646733781779	no2019179166	female		graduate	Columba College			winner	University of Pittsburg Press	Drue Heinz Literature Prize	2019	prose	book	15000.0	Driving In Cars With Homeless Men
 1223	Josephine Humphreys	Josephine	Humphreys	Q6288383	Josephine Humphreys	25272871	n83175538	female	Yale University	graduate				winner	PEN America	Hemingway Award for Debut Novel	1985	prose	book	10000.0	Dreams Of Sleep
 1459	Lynn Emanuel	Lynn	Emanuel	Q6709010	Lynn Emanuel	30808737	n79017241	female		graduate	University of Iowa	1431		judge	National Book Foundation	National Book Award	2004	poetry	book	10000.0	Door In The Mountain: New And Collected Poems, 1965-2003
 1033	Jean Valentine	Jean	Valentine	Q14948838	Jean Valentine	161665325	n79027012	female	Radcliffe College	graduate				winner	National Book Foundation	National Book Award	2004	poetry	book	10000.0	Door In The Mountain: New And Collected Poems, 1965-2003
 1697	Naomi Shihab Nye	Naomi Shihab	Nye	Q2896906	Naomi Shihab Nye	14861586	n81085291	female						judge	National Book Foundation	National Book Award	2004	poetry	book	10000.0	Door In The Mountain: New And Collected Poems, 1965-2003
-1619	Melissa Yancy	Melissa	Yancy					female		graduate	University of Southern California			winner	University of Pittsburg Press	Drue Heinz Literature Prize	2016	prose	book	15000.0	Dog Years
+1619	Melissa Yancy	Melissa	Yancy			274147423188144882494	n2016046842	female		graduate	University of Southern California			winner	University of Pittsburg Press	Drue Heinz Literature Prize	2016	prose	book	15000.0	Dog Years
 672	Elizabeth Hardwick	Elizabeth	Hardwick	Q465242	Elizabeth Hardwick	22261787	n79077178	female						judge	National Book Foundation	National Book Award	1975	prose	book	10000.0	Dog Soldiers & The Hair Of Harold Roux
 575	Diana Khoi Nguyen	Diana Khoi	Nguyen	Q63692475	Diana Khoi Nguyen			female	Columbia University	graduate	Columbia University			judge	National Book Foundation	National Book Award	2020	poetry	book	10000.0	DMZ Colony
 1366	Layli Long Soldier	Layli	Long Soldier	Q27979062	Layli Long Soldier	103053566	no2009185035	female		graduate	Bard College			judge	National Book Foundation	National Book Award	2020	poetry	book	10000.0	DMZ Colony
@@ -5476,7 +5476,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1401	Linda Gregerson	Linda	Gregerson	Q6551613	Linda Gregerson	29682677	n83187938	female	Stanford University	graduate	University of Iowa	1007		judge	Columbia University	Pulitzer Prize	2005	poetry	book	15000.0	Delights And Shadows
 1667	Molly McCloskey	Molly	McCloskey	Q1943634	Molly McCloskey	92924923	nr98003064	female		graduate				judge	PEN America	Faulkner Award for Fiction	2016	prose	book	15000.0	Delicious Foods
 8	Abby Frucht	Abby	Frucht					female						judge	PEN America	Faulkner Award for Fiction	2016	prose	book	15000.0	Delicious Foods
-22	Adriana Ramirez	Adriana	Ramirez					female		graduate	University of Pittsburgh			winner	PEN America	Fusion Emerging Writers Prize	2015	prose	book	10000.0	Dead Boys
+22	Adriana Ramirez	Adriana	Ramirez	Q113679875	Adriana E. Ramírez			female		graduate	University of Pittsburgh			winner	PEN America	Fusion Emerging Writers Prize	2015	prose	book	10000.0	Dead Boys
 439	Cristina Henríquez	Cristina	Henríquez	Q18719470	Cristina Henríquez	166101706	n2005057786	female		graduate	University of Iowa	missing		judge	PEN America	Fusion Emerging Writers Prize	2015	prose	book	10000.0	Dead Boys
 2022	Roxane Gay	Roxane	Gay	Q16202911	Roxane Gay	308698170	no2014051741	female		graduate				judge	PEN America	Fusion Emerging Writers Prize	2015	prose	book	10000.0	Dead Boys
 439	Cristina Henríquez	Cristina	Henríquez	Q18719470	Cristina Henríquez	166101706	n2005057786	female		graduate	University of Iowa	missing		judge	PEN America	Fusion Emerging Writers Prize	2016	prose	book	10000.0	Crux
@@ -5496,7 +5496,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 842	Gwendolyn Brooks	Gwendolyn	Brooks	Q270715	Gwendolyn Brooks	113723435	n50041281	female						judge	National Book Foundation	National Book Award	1977	poetry	book	10000.0	Collected Poems, 1930-1976: Including 43 New Poems
 1606	May Swenson	May	Swenson	Q1026443	May Swenson	37043756	n50011616	female						judge	Academy of American Poets	Lenore Marshall Poetry Prize	1978	poetry	book	25000.0	Collected Poems, 1919-1976
 1378	Leonie Adams	Leonie	Adams	Q467163	Léonie Adams	114359194	n81117461	female	Barnard College					judge	National Book Foundation	National Book Award	1953	poetry	book	10000.0	Collected Poems, 1917-1952
-746	Francis Ferguson	Francis	Ferguson					female	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1972	poetry	book	15000.0	Collected Poems
+746	Francis Ferguson	Francis	Ferguson	Q49773016	Antony Francis Ferguson Davie, 6th Bt.	63505614	nb99070544	female	Yale University	graduate				judge	Columbia University	Pulitzer Prize	1972	poetry	book	15000.0	Collected Poems
 877	Helen Vendler	Helen	Vendler	Q5703331	Helen Vendler	108450526	n79095151	female	Harvard University	graduate				judge	Columbia University	Pulitzer Prize	1978	poetry	book	15000.0	Collected Poems
 1276	Katherine Garrison Chapin	Katherine Garrison	Chapin	Q1736241	Katherine Garrison Chapin	45634544	n81147752	female	Columbia University					judge	National Book Foundation	National Book Award	1954	poetry	book	10000.0	Collected Poems
 1504	Marianne Moore	Marianne	Moore	Q278495	Marianne Moore	61562401	n50016866	female						winner	National Book Foundation	National Book Award	1952	poetry	book	10000.0	Collected Poems
@@ -5565,7 +5565,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 343	Chantel Acevedo	Chantel	Acevedo					female		graduate	University of Miami			judge	PEN America	Faulkner Award for Fiction	2017	prose	book	15000.0	Behold The Dreamers
 2107	Sigrid Nunez	Sigrid	Nunez	Q7513133	Sigrid Nunez	27280224	n94067451	female	Barnard College, Columbia University	graduate	Columbia University			judge	PEN America	Faulkner Award for Fiction	2017	prose	book	15000.0	Behold The Dreamers
 920	Imbolo Mbue	Imbolo	Mbue	Q23816363	Imbolo Mbue	315176836	n2015021216	female	Columbia University	graduate				winner	PEN America	Faulkner Award for Fiction	2017	prose	book	15000.0	Behold The Dreamers
-479	Danielle Evans	Danielle	Evans	Q16210805	Danielle Valore Evans		n2010012011	female	Columbia University	graduate	University of Iowa	3868		winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2011	prose	book	25000.0	Before You Suffocate Your Own Fool Self
+479	Danielle Evans	Danielle	Evans					female	Columbia University	graduate	University of Iowa	3868		winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2011	prose	book	25000.0	Before You Suffocate Your Own Fool Self
 406	Claire Vaye Watkins	Claire Vaye	Watkins	Q16211192	Claire Vaye Watkins	233086608	n2012017032	female		graduate	Ohio State University			winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2013	prose	book	10000.0	Battleborn
 85	Alison Lurie	Alison	Lurie	Q272638	Alison Lurie	29537282	n79103776	female	Radcliffe College					judge	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2013	prose	book	10000.0	Battleborn
 744	Francine Prose	Francine	Prose	Q2427599	Francine Prose	112469802	n50020196	female	Radcliffe College					judge	American Academy of Arts and Letters	Rosenthal Family Foundation Award	2013	prose	book	10000.0	Battleborn
@@ -5575,7 +5575,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2328	Wanda Coleman	Wanda	Coleman	Q7967107	Wanda Coleman	79081042	n79017249	female						winner	Academy of American Poets	Lenore Marshall Poetry Prize	1999	poetry	book	25000.0	Bathwater Wine
 3	A. G. Mojtabai	A. G.	Mojtabai	Q110940858	A. G. Mojtabai	30091182	n79091270	female	Columbia University	graduate				winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1983	prose	book	10000.0	Autumn
 898	Hillary Jordan	Hillary	Jordan	Q5762565	Hillary Jordan	189145542663796641977	n2007079280	female	Columbia University	graduate	Columbia University			judge	PEN America	Bellwether Prize for Socially Engaged Fiction	2019	prose	book	25000.0	At The Edge Of The Haight
-1279	Katherine Seligman	Katherine	Seligman					female	Stanford University	graduate				winner	PEN America	Bellwether Prize for Socially Engaged Fiction	2019	prose	book	25000.0	At The Edge Of The Haight
+1279	Katherine Seligman	Katherine	Seligman			4159636941343110915	n2020042410	female	Stanford University	graduate				winner	PEN America	Bellwether Prize for Socially Engaged Fiction	2019	prose	book	25000.0	At The Edge Of The Haight
 218	Barbara Kingsolver	Barbara	Kingsolver	Q1264643	Barbara Kingsolver	79097759	n87839639	female		graduate				judge	PEN America	Bellwether Prize for Socially Engaged Fiction	2019	prose	book	25000.0	At The Edge Of The Haight
 1288	Kathy Pories	Kathy	Pories					female		graduate				judge	PEN America	Bellwether Prize for Socially Engaged Fiction	2019	prose	book	25000.0	At The Edge Of The Haight
 1090	Joanna Scott	Joanna	Scott	Q6205957	Joanna Scott	46798884	no91009696	female	Brown University	graduate				winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1991	prose	book	10000.0	Arrogance
@@ -5626,8 +5626,8 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2204	Terese Marie Mailhot	Terese Marie	Mailhot	Q50379458	Terese Marie Mailhot	7150999546329870738	n2017066267	female		graduate	Institute of American Indian Arts			judge	PEN America	Hemingway Award for Debut Novel	2020	prose	book	10000.0	A Prayer For Travelers
 2028	Ruchika Tomar	Ruchika	Tomar	Q98510714	Ruchika Tomar	1154135795715082757	n2018062037	female	Columbia University	graduate	Columbia University			winner	PEN America	Hemingway Award for Debut Novel	2020	prose	book	10000.0	A Prayer For Travelers
 1941	Ro Kwon	Ro	Kwon	Q56641357	R. O. Kwon	5153361344737392019	no2018100529	female	Yale University	graduate	Brooklyn College			judge	PEN America	Hemingway Award for Debut Novel	2020	prose	book	10000.0	A Prayer For Travelers
-479	Danielle Evans	Danielle	Evans	Q16210805	Danielle Valore Evans		n2010012011	female	Columbia University	graduate	University of Iowa	3868		judge	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2013	prose	book	25000.0	A Naked Singularity
-1017	Janna Levin	Janna	Levin					female	Barnard College	graduate				winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2007	prose	book	25000.0	A Madman Dreams Of Turing Machines
+479	Danielle Evans	Danielle	Evans					female	Columbia University	graduate	University of Iowa	3868		judge	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2013	prose	book	25000.0	A Naked Singularity
+1017	Janna Levin	Janna	Levin	Q6155075		74111260	nb2001028833	female	Barnard College	graduate				winner	PEN America	Robert W. Bingham Prize for Debut Short Story Collection	2007	prose	book	25000.0	A Madman Dreams Of Turing Machines
 289	Brigid Pasulka	Brigid	Pasulka	Q4967855	Brigid Pasulka			female	Dartmouth College	graduate				winner	PEN America	Hemingway Award for Debut Novel	2010	prose	book	10000.0	A Long Long Time Ago And Essentially True
 779	Gail Tsukiyama	Gail	Tsukiyama	Q5517172	Gail Tsukiyama	79363825	n91049428	female		graduate				judge	PEN America	Hemingway Award for Debut Novel	2010	prose	book	10000.0	A Long Long Time Ago And Essentially True
 1240	Julia Glass	Julia	Glass	Q6306433	Julia Glass	120654826	n2001052456	female	Yale University					judge	PEN America	Hemingway Award for Debut Novel	2010	prose	book	10000.0	A Long Long Time Ago And Essentially True
@@ -5636,7 +5636,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1727	Nicole Magistro	Nicole	Magistro					female						judge	Kirkus Review	Kirkus Prize	2015	prose	book	50000.0	A Little Life
 162	Anne Tyler	Anne	Tyler	Q235615	Anne Tyler	39384885	n79100453	female						judge	Columbia University	Pulitzer Prize	1993	prose	book	15000.0	A Good Scent From A Strange Mountain
 139	Anita Shreve	Anita	Shreve	Q460425	Anita Shreve	32082253	n84219960	female						judge	PEN America	Hemingway Award for Debut Novel	2009	prose	book	10000.0	A Gentleman's Guide To Graceful Living
-1233	Joyce Carol Oates	Joyce Carol	Oates	Q217557	Joyce Carol Oates	7662418	n87851370	female		graduate				winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1968	prose	book	10000.0	A Garden Of Earthly Delights
+1233	Joyce Carol Oates	Joyce Carol	Oates	Q217557	Joyce Carol Oates	46791148	n87851370	female		graduate				winner	American Academy of Arts and Letters	Rosenthal Family Foundation Award	1968	prose	book	10000.0	A Garden Of Earthly Delights
 2181	Susanna Kaysen	Susanna	Kaysen	Q257723	Susanna Kaysen	88222694	n86109794	female						judge	National Book Foundation	National Book Award	1994	prose	book	10000.0	A Frolic Of His Own
 107	Amy Hempel	Amy	Hempel	Q481871	Amy Hempel	79156172	n84183486	female						judge	National Book Foundation	National Book Award	1994	prose	book	10000.0	A Frolic Of His Own
 924	Irita Van Doren	Irita	Van Doren	Q16004119	Irita Bradford Van Doren	48495151	n96066126	female	Columbia University	graduate				judge	Columbia University	Pulitzer Prize	1963	prose	book	15000.0	A Fable
@@ -5748,7 +5748,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 288	Brighde Mullins	Brighde	Mullins	Q15441213	Brighde Mullins	68743121	no2008085993	female	Yale University	graduate	University of Iowa, Yale University	1945		winner	Whiting Foundation	Whiting Award	2001	no genre	career	50000.0	
 2162	Sujikwock Kim	Sujikwock	Kim					female	Yale University, Stanford University	graduate	University of Iowa	2303	Stegner	winner	American Academy of Arts and Letters	Metcalf Awards	2007	no genre	career	10000.0	
 2162	Sujikwock Kim	Sujikwock	Kim					female	Yale University, Stanford University	graduate	University of Iowa	2303	Stegner	winner	Whiting Foundation	Whiting Award	2006	no genre	career	50000.0	
-2406	Z. Z. Packer	Z. Z.	Packer 					female	Yale University, Stanford University	graduate	University of Iowa	2421	Stegner	winner	Whiting Foundation	Whiting Award	1999	no genre	career	50000.0	
+2406	Z. Z. Packer	Z. Z.	Packer 	Q8063320	ZZ Packer	102738488	n2002037157	female	Yale University, Stanford University	graduate	University of Iowa	2421	Stegner	winner	Whiting Foundation	Whiting Award	1999	no genre	career	50000.0	
 1340	Lan Samantha Chang	Lan Samantha	Chang	Q6482805	Lan Samantha Chang	25483528	n98015225	female	Yale University, Harvard University, Stanford University	graduate	University of Iowa	2117	Stegner	judge	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2006	no genre	career	50000.0	
 1401	Linda Gregerson	Linda	Gregerson	Q6551613	Linda Gregerson	29682677	n83187938	female	Stanford University	graduate	University of Iowa	1007		judge	Academy of American Poets	Academy of American Poets Fellowship	2020	poetry	career	25000.0	
 1401	Linda Gregerson	Linda	Gregerson	Q6551613	Linda Gregerson	29682677	n83187938	female	Stanford University	graduate	University of Iowa	1007		judge	Academy of American Poets	Academy of American Poets Fellowship	2019	poetry	career	25000.0	
@@ -5795,7 +5795,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 273	Brenda Hillman	Brenda	Hillman	Q4960695	Brenda Hillman	93929850	n84045053	female		graduate	University of Iowa	934		judge	Academy of American Poets	Wallace Stevens Award	2018	poetry	career	100000.0	
 273	Brenda Hillman	Brenda	Hillman	Q4960695	Brenda Hillman	93929850	n84045053	female		graduate	University of Iowa	934		judge	Academy of American Poets	Wallace Stevens Award	2017	poetry	career	100000.0	
 273	Brenda Hillman	Brenda	Hillman	Q4960695	Brenda Hillman	93929850	n84045053	female		graduate	University of Iowa	934		judge	Academy of American Poets	Wallace Stevens Award	2016	poetry	career	100000.0	
-315	Carmen Giménez-Smith	Carmen	Giménez-Smith	Q5043476	Carmen Giménez	78259941	n2008083066	female		graduate	University of Iowa	3905		winner	Academy of American Poets	Academy of American Poets Fellowship	2020	poetry	career	25000.0	
+315	Carmen Giménez-Smith	Carmen	Giménez-Smith					female		graduate	University of Iowa	3905		winner	Academy of American Poets	Academy of American Poets Fellowship	2020	poetry	career	25000.0	
 332	Cate Marvin	Cate	Marvin	Q5051784	Cate Marvin	62777340	n00043223	female		graduate	University of Iowa	2414		winner	Whiting Foundation	Whiting Award	2007	no genre	career	50000.0	
 339	Cathy Wagner	Cathy	Wagner					female		graduate	University of Iowa	2501		winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	1990	poetry	career	15000.0	
 340	Cathypark Hong	Cathypark	Hong					female		graduate	University of Iowa	2558		winner	Yale University	Windham Campbell Prize	2018	poetry	career	165000.0	
@@ -5826,7 +5826,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 685	Ellen Bryant Voigt	Ellen Bryant	Voigt	Q5364772	Ellen Bryant Voigt	44451870	n82108931	female		graduate	University of Iowa	270		judge	Academy of American Poets	Wallace Stevens Award	2004	poetry	career	100000.0	
 740	Flannery O'Connor	Flannery	O'Connor	Q234579	Flannery O'Connor	17227472	n79119229	female		graduate	University of Iowa	4328		winner	American Academy of Arts and Letters	Arts and Letters Awards	1957	no genre	career	10000.0	
 852	Hannah Sanghee Park	Hannah Sanghee	Park	Q58643075	Hannah Sanghee Park	310712953	n2014060396	female		graduate	University of Iowa	2831		winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2013	poetry	career	25800.0	
-1002	Jane Cooper	Jane	Cooper					female		graduate	University of Iowa	3372		winner	American Academy of Arts and Letters	Arts and Letters Awards	1995	no genre	career	10000.0	
+1002	Jane Cooper	Jane	Cooper	Q6151271	Jane Cooper	235768947	n82087761	female		graduate	University of Iowa	3372		winner	American Academy of Arts and Letters	Arts and Letters Awards	1995	no genre	career	10000.0	
 1005	Jane Huffman	Jane	Huffman	Q91686484	Jane Huffman			female		graduate	University of Iowa	missing		winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2019	poetry	career	25800.0	
 1008	Jane Mead	Jane	Mead	Q15030215	Jane Mead	76188894	nr93024298	female		graduate	University of Iowa	1863		winner	Whiting Foundation	Whiting Award	1992	no genre	career	50000.0	
 1009	Jane Smiley	Jane	Smiley	Q441067	Jane Smiley	19714915	n79143875	female		graduate	University of Iowa	969		winner	American Academy of Arts and Letters	Arts and Letters Awards	1997	no genre	career	10000.0	
@@ -5952,7 +5952,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1621	Merritt Tierce	Merritt	Tierce	Q91683342	Merritt Tierce			female		graduate	University of Iowa	4274		winner	Whiting Foundation	Whiting Award	2019	no genre	career	50000.0	
 1649	Michelle Huneven	Michelle	Huneven	Q6837086	Michelle Huneven	1748496	n97015243	female		graduate	University of Iowa	1014		winner	Whiting Foundation	Whiting Award	2002	no genre	career	50000.0	
 1698	Naomi Wallace	Naomi	Wallace	Q3335849	Naomi Wallace	54044797	nr96005990	female		graduate	University of Iowa	missing		winner	American Academy of Arts and Letters	Arts and Letters Awards	2015	no genre	career	10000.0	
-1744	Novuyo Rosa Tshuma	Novuyo Rosa	Tshuma	Q26772550	Novuyo Tshuma	307453447	no2014008030	female		graduate	University of Iowa	missing		winner	Lannan Foundation	Lannan Fellowship	2020	prose	career	50000.0	
+1744	Novuyo Rosa Tshuma	Novuyo Rosa	Tshuma					female		graduate	University of Iowa	missing		winner	Lannan Foundation	Lannan Fellowship	2020	prose	career	50000.0	
 1750	Olivia Clare	Olivia	Clare					female		graduate	University of Iowa	2719		winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2011	poetry	career	25800.0	
 1764	Pam Durban	Pam	Durban	Q7128929	Pam Durban	21096206	n84220159	female		graduate	University of Iowa	1144		winner	Whiting Foundation	Whiting Award	1987	no genre	career	50000.0	
 1939	Rita Dove	Rita	Dove	Q445740	Rita Dove	39400140	n80111701	female		graduate	University of Iowa	966		judge	Academy of American Poets	Academy of American Poets Fellowship	2011	poetry	career	25000.0	
@@ -5980,12 +5980,12 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2400	Yiyun Li	Yiyun	Li	Q460088	Yiyun Li	66761360	n2004151571	female		graduate	University of Iowa	4032		winner	Whiting Foundation	Whiting Award	2006	no genre	career	50000.0	
 2400	Yiyun Li	Yiyun	Li	Q460088	Yiyun Li	66761360	n2004151571	female		graduate	University of Iowa	4032		winner	Yale University	Windham Campbell Prize	2020	prose	career	165000.0	
 1687	Nafissa Thompson-Spires	Nafissa	Thompson-Spires	Q105518060	Nafissa Thompson-Spires			female		graduate	University of Illinois			winner	Whiting Foundation	Whiting Award	2019	no genre	career	50000.0	
-1725	Nicky Beer	Nicky	Beer	Q95654388	Nicky Beer	132940174		female	Yale University	graduate	University of Houston			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2008	poetry	career	25800.0	
+1725	Nicky Beer	Nicky	Beer	Q95654388	Nicky Beer	132940174	no2010118654	female	Yale University	graduate	University of Houston			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2008	poetry	career	25800.0	
 850	Hannah Gamble	Hannah	Gamble	Q113720011	Hannah Gamble	296997747	no2013013865	female		graduate	University of Houston			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2014	poetry	career	25800.0	
 1692	Nancy Eimers	Nancy	Eimers	Q6962669	Nancy Eimers	11474851	n90709590	female		graduate	University of Houston			winner	Whiting Foundation	Whiting Award	1998	no genre	career	50000.0	
-2293	Vanessa Angélica Villarreal	Vanessa Angélica	Villarreal					female		graduate	University of Colorado			winner	Whiting Foundation	Whiting Award	2019	no genre	career	50000.0	
+2293	Vanessa Angélica Villarreal	Vanessa Angélica	Villarreal	Q66716633	Vanessa Angélica Villarreal	18153651659455780802	no2018114523	female		graduate	University of Colorado			winner	Whiting Foundation	Whiting Award	2019	no genre	career	50000.0	
 2095	Sheila Callaghan	Sheila	Callaghan	Q7493020	Sheila Callaghan	30145970224732251721	no2007102618	female		graduate	University of California, Los Angeles			winner	Whiting Foundation	Whiting Award	2007	no genre	career	50000.0	
-239	Beth Ann Fennelly	Beth Ann	Fennelly					female		graduate	University of Arkansas			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2006	no genre	career	50000.0	
+239	Beth Ann Fennelly	Beth Ann	Fennelly	Q13563255	Beth Ann Fennelly	264901884	n97119513	female		graduate	University of Arkansas			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2006	no genre	career	50000.0	
 300	C. D. Wright	C. D.	Wright	Q5045339	Carolyn D. Wright	22444328	n82119208	female		graduate	University of Arkansas			judge	Academy of American Poets	Academy of American Poets Fellowship	2015	poetry	career	25000.0	
 300	C. D. Wright	C. D.	Wright	Q5045339	Carolyn D. Wright	22444328	n82119208	female		graduate	University of Arkansas			judge	Academy of American Poets	Academy of American Poets Fellowship	2014	poetry	career	25000.0	
 300	C. D. Wright	C. D.	Wright	Q5045339	Carolyn D. Wright	22444328	n82119208	female		graduate	University of Arkansas			judge	Academy of American Poets	Academy of American Poets Fellowship	2013	poetry	career	25000.0	
@@ -5996,14 +5996,14 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 300	C. D. Wright	C. D.	Wright	Q5045339	Carolyn D. Wright	22444328	n82119208	female		graduate	University of Arkansas			judge	Academy of American Poets	Wallace Stevens Award	2014	poetry	career	100000.0	
 300	C. D. Wright	C. D.	Wright	Q5045339	Carolyn D. Wright	22444328	n82119208	female		graduate	University of Arkansas			judge	Academy of American Poets	Wallace Stevens Award	2013	poetry	career	100000.0	
 300	C. D. Wright	C. D.	Wright	Q5045339	Carolyn D. Wright	22444328	n82119208	female		graduate	University of Arkansas			winner	Whiting Foundation	Whiting Award	1989	no genre	career	50000.0	
-376	Chloe Honum	Chloe	Honum					female		graduate	University of Arkansas			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2009	poetry	career	25800.0	
-143	Ann Cummins	Ann	Cummins	Q4766343	Ann Cummins	267102924		female		graduate	University of Arizona			winner	Lannan Foundation	Lannan Fellowship	2002	prose	career	50000.0	
+376	Chloe Honum	Chloe	Honum	Q55713469	Chloe Honum	305446573	n2013072077	female		graduate	University of Arkansas			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2009	poetry	career	25800.0	
+143	Ann Cummins	Ann	Cummins	Q4766343	Ann Cummins	267102924	n2002047667	female		graduate	University of Arizona			winner	Lannan Foundation	Lannan Fellowship	2002	prose	career	50000.0	
 180	Antonya Nelson	Antonya	Nelson	Q4777267	Antonya Nelson	79367826	n88231854	female		graduate	University of Arizona			judge	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2010	no genre	career	50000.0	
 180	Antonya Nelson	Antonya	Nelson	Q4777267	Antonya Nelson	79367826	n88231854	female		graduate	University of Arizona			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2009	no genre	career	50000.0	
 1199	Jos Charles	Jos	Charles	Q61450151	Jos Charles	32146331865518691537	n2016022491	female		graduate	University of Arizona			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2016	poetry	career	25800.0	
 2198	Tayari Jones	Tayari	Jones	Q7689755	Tayari Jones	65814928	n2001039535	female		graduate	University of Arizona			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2008	no genre	career	50000.0	
 1700	Natalie Kusz	Natalie	Kusz	Q6968194	Natalie Kusz	79360258	n90620503	female		graduate	University of Alaska Fairbanks			winner	Whiting Foundation	Whiting Award	1989	no genre	career	50000.0	
-1358	Lauren Yee	Lauren	Yee					female	Yale University	graduate	Univeristy of California, San Diego			winner	American Academy of Arts and Letters	Arts and Letters Awards	2019	no genre	career	10000.0	
+1358	Lauren Yee	Lauren	Yee	Q25189708	Lauren Yee	204633220	no2011177052	female	Yale University	graduate	Univeristy of California, San Diego			winner	American Academy of Arts and Letters	Arts and Letters Awards	2019	no genre	career	10000.0	
 1696	Naomi Iizuka	Naomi	Iizuka	Q13563013	Naomi Iizuka	1242110	n00030439	female	Yale University	graduate	Univeristy of California, San Diego			winner	Whiting Foundation	Whiting Award	1999	no genre	career	50000.0	
 488	Danzy Senna	Danzy	Senna	Q5221478	Danzy Senna	92928559	n97076092	female	Stanford University	graduate	Univeristy of California, Irvine			winner	Whiting Foundation	Whiting Award	2002	no genre	career	50000.0	
 1476	Maile Meloy	Maile	Meloy	Q541890	Maile Meloy	49469571	n2001045237	female	Harvard University	graduate	Univeristy of California, Irvine			judge	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2006	no genre	career	50000.0	
@@ -6013,7 +6013,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1070	Jill Ciment	Jill	Ciment	Q6192766	Jill Ciment	79366059	n85243081	female		graduate	Univeristy of California, Irvine			judge	PEN America	W. G. Sebald Award For Fiction Writer In Mid-Career	2011	prose	career	10000.0	
 405	Claire Messud	Claire	Messud	Q529082	Claire Messud	119451282	n95012238	female	Yale University	graduate	Syracuse University			winner	American Academy of Arts and Letters	Metcalf Awards	2002	no genre	career	10000.0	
 405	Claire Messud	Claire	Messud	Q529082	Claire Messud	119451282	n95012238	female	Yale University	graduate	Syracuse University			winner	American Academy of Arts and Letters	Mildred And Harold Strauss Livings	2003	prose	career	100000.0	
-791	Genevieve Sly Crane	Genevieve Sly	Crane					female		graduate	SUNY Stonybrook			winner	Whiting Foundation	Whiting Award	2020	no genre	career	50000.0	
+791	Genevieve Sly Crane	Genevieve Sly	Crane	Q120768578	Genevieve Sly Crane	10152682479623310470	no2018060160	female		graduate	SUNY Stonybrook			winner	Whiting Foundation	Whiting Award	2020	no genre	career	50000.0	
 248	Bhanu Kapil	Bhanu	Kapil	Q19667597	Bhanu Kapil	29085938	no00099586	female		graduate	SUNY Brookport			winner	Yale University	Windham Campbell Prize	2020	poetry	career	165000.0	
 440	Crystal Wilkinson	Crystal	Wilkinson	Q5191401	Crystal Wilkinson	53805192	no2001072848	female		graduate	Spalding University			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2020	no genre	career	50000.0	
 1685	Nadia Owusu	Nadia	Owusu	Q105427865	Nadia Owusu	7158488564511731329	n2020014485	female		graduate	Southern New Hampshire University			winner	Whiting Foundation	Whiting Award	2019	no genre	career	50000.0	
@@ -6026,7 +6026,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1699	Natalie Diaz	Natalie	Diaz	Q16974419	Natalie Diaz	227752265	n2012003417	female		graduate	Old Dominion University			judge	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2016	no genre	career	50000.0	
 1699	Natalie Diaz	Natalie	Diaz	Q16974419	Natalie Diaz	227752265	n2012003417	female		graduate	Old Dominion University			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2014	no genre	career	50000.0	
 406	Claire Vaye Watkins	Claire Vaye	Watkins	Q16211192	Claire Vaye Watkins	233086608	n2012017032	female		graduate	Ohio State University			winner	Lannan Foundation	Lannan Fellowship	2018	prose	career	50000.0	
-1702	Natalie Shapero	Natalie	Shapero					female		graduate	Ohio State University			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2013	poetry	career	25800.0	
+1702	Natalie Shapero	Natalie	Shapero	Q55713433	Natalie Shapero	299713107	no2013048074	female		graduate	Ohio State University			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2013	poetry	career	25800.0	
 1937	Rinne Groff	Rinne	Groff	Q7335074	Rinne Groff	46532214	no2007009982	female	Yale University	graduate	New York University			winner	Whiting Foundation	Whiting Award	2005	no genre	career	50000.0	
 2114	Solmaz Sharif	Solmaz	Sharif	Q26703018	Solmaz Sharif	42147543864553192936		female	Stanford University	graduate	New York University		Stegner	winner	Lannan Foundation	Lannan Fellowship	2016	poetry	career	50000.0	
 2114	Solmaz Sharif	Solmaz	Sharif	Q26703018	Solmaz Sharif	42147543864553192936		female	Stanford University	graduate	New York University		Stegner	winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2014	poetry	career	25800.0	
@@ -6041,22 +6041,22 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 181	Aracelis Girmay	Aracelis	Girmay	Q28648926	Aracelis Girmay	28922635	n2004046227	female		graduate	New York University			winner	Whiting Foundation	Whiting Award	2015	no genre	career	50000.0	
 184	Aria Aber	Aria	Aber	Q95076006	Aria Aber			female		graduate	New York University			winner	Whiting Foundation	Whiting Award	2020	no genre	career	50000.0	
 416	Claudia Roth Pierpont	Claudia	Roth Pierpont	Q5129249	Claudia Roth Pierpont	64227272	n97868106	female		graduate	New York University			judge	PEN America	Saul Bellow Award For Achievement In American Fiction	2009	prose	career	25000.0	
-416	Claudia Roth Pierpont	Claudia	Roth Pierpont					female		graduate	New York University			winner	Whiting Foundation	Whiting Award	1994	no genre	career	50000.0	
+416	Claudia Roth Pierpont	Claudia	Roth Pierpont	Q5129249	Claudia Roth Pierpont	64227272	n97868106	female		graduate	New York University			winner	Whiting Foundation	Whiting Award	1994	no genre	career	50000.0	
 433	Courtney Brkic	Courtney	Brkic					female		graduate	New York University			winner	Whiting Foundation	Whiting Award	2003	no genre	career	50000.0	
 461	Dana Levin	Dana	Levin	Q5214775	Dana Levin	6930697	no00012007	female		graduate	New York University			winner	Whiting Foundation	Whiting Award	2005	no genre	career	50000.0	
 463	Danai Gurira	Danai	Gurira	Q636653	Danai Gurira	274583701	no2008162135	female		graduate	New York University			winner	Whiting Foundation	Whiting Award	2012	no genre	career	50000.0	
 579	Diannely Antigua	Diannely	Antigua					female		graduate	New York University			winner	Whiting Foundation	Whiting Award	2020	no genre	career	50000.0	
 1282	Kathleen Graber	Kathleen	Graber	Q23884222	Kathleen Graber	9596828	no2006045472	female		graduate	New York University			winner	American Academy of Arts and Letters	Arts and Letters Awards	2017	no genre	career	10000.0	
-1334	L. B. Thompson	L. B.	Thompson					female		graduate	New York University			winner	Whiting Foundation	Whiting Award	2010	no genre	career	50000.0	
+1334	L. B. Thompson	L. B.	Thompson	Q21064594	L.B. Thompson			female		graduate	New York University			winner	Whiting Foundation	Whiting Award	2010	no genre	career	50000.0	
 1467	Maaza Mengiste	Maaza	Mengiste	Q3841903	Maaza Mengiste	96758846	n2009054685	female		graduate	New York University			winner	American Academy of Arts and Letters	Arts and Letters Awards	2020	no genre	career	10000.0	
 2041	Safia Elhillo	Safia	Elhillo	Q29913403	Safia Elhillo	105146461554227731538	no2016068432	female	Stanford University	graduate	New School for Social Research		Stegner	winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2018	poetry	career	25800.0	
-2110	Simone White	Simone	White	Q97619986	Simone White	144674223		female		graduate	New School for Social Research			winner	Whiting Foundation	Whiting Award	2017	no genre	career	50000.0	
+2110	Simone White	Simone	White	Q97619986	Simone White	144674223	no2010169806	female		graduate	New School for Social Research			winner	Whiting Foundation	Whiting Award	2017	no genre	career	50000.0	
 1383	Lesley Nneka Arimah	Lesley Nneka	Arimah	Q45849301	Lesley Nneka Arimah	8089151112594537180004	n2016059711	female		graduate	Minnesota State University			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2019	no genre	career	50000.0	
 624	Edie Meidav	Edie	Meidav	Q5338028	Edie Meidav	84511476	n00043661	female	Yale University	graduate	Mills College			winner	Lannan Foundation	Lannan Fellowship	2007	prose	career	50000.0	
 1339	Laleh Khadivi	Laleh	Khadivi	Q6480248	Laleh Khadivi	78732603	nr2005000972	female		graduate	Mills College			winner	Whiting Foundation	Whiting Award	2008	no genre	career	50000.0	
-1648	Micheline Marcom	Micheline	Marcom					female		graduate	Mills College			winner	Lannan Foundation	Lannan Fellowship	2004	prose	career	50000.0	
-1648	Micheline Marcom	Micheline	Marcom					female		graduate	Mills College			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2012	no genre	career	50000.0	
-1648	Micheline Marcom	Micheline	Marcom					female		graduate	Mills College			winner	Whiting Foundation	Whiting Award	2006	no genre	career	50000.0	
+1648	Micheline Marcom	Micheline	Marcom	Q6836889	Micheline Aharonian Marcom	24935502	n00043591	female		graduate	Mills College			winner	Lannan Foundation	Lannan Fellowship	2004	prose	career	50000.0	
+1648	Micheline Marcom	Micheline	Marcom	Q6836889	Micheline Aharonian Marcom	24935502	n00043591	female		graduate	Mills College			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2012	no genre	career	50000.0	
+1648	Micheline Marcom	Micheline	Marcom	Q6836889	Micheline Aharonian Marcom	24935502	n00043591	female		graduate	Mills College			winner	Whiting Foundation	Whiting Award	2006	no genre	career	50000.0	
 372	Chimamanda Ngozi Adichie	Chimamanda Ngozi	Adichie	Q230141	Chimamanda Ngozi Adichie	87194517	n2003042876	female	Yale University	graduate	Johns Hopkins University			winner	MacArthur Foundation	MacArthur Fellowship	2008	no genre	career	500000.0	
 2015	Rosanna Warren	Rosanna	Warren	Q7367344	Rosanna Warren	64050468	n84089568	female	Yale University	graduate	Johns Hopkins University			judge	Academy of American Poets	Academy of American Poets Fellowship	2005	poetry	career	25000.0	
 2015	Rosanna Warren	Rosanna	Warren	Q7367344	Rosanna Warren	64050468	n84089568	female	Yale University	graduate	Johns Hopkins University			judge	Academy of American Poets	Academy of American Poets Fellowship	2004	poetry	career	25000.0	
@@ -6119,7 +6119,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1562	Mary Karr	Mary	Karr	Q1598388	Mary Karr	94096111	n85249942	female		graduate	Goddard College			winner	Whiting Foundation	Whiting Award	1989	no genre	career	50000.0	
 566	Delisa Mulkey	Delisa	Mulkey					female		graduate	Georgia State University			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	1997	poetry	career	15000.0	
 1285	Kathleen Rooney	Kathleen	Rooney	Q6376889	Kathleen Rooney	76650758	n2004103913	female		graduate	Emerson College			winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2003	poetry	career	25800.0	
-1879	Rebecca Gayle Howell	Rebecca Gayle	Howell	Q18687856	Rebecca Gayle Howell		n2009015582	female		graduate	Drew University			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2019	no genre	career	50000.0	
+1879	Rebecca Gayle Howell	Rebecca Gayle	Howell	Q18687856	Rebecca Gayle Howell	83482141	n2009015582	female		graduate	Drew University			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2019	no genre	career	50000.0	
 2166	Susan Choi	Susan	Choi	Q7647669	Susan Choi	80525953	n98008820	female	Yale University, Cornell University	graduate	Cornell University			winner	PEN America	W. G. Sebald Award For Fiction Writer In Mid-Career	2010	prose	career	10000.0	
 1406	Ling Ma	Ling	Ma 	Q56427737	Ling Ma	81150746895516300033	n2017060146	female	University of Chicago, Cornell University	graduate	Cornell University			winner	Whiting Foundation	Whiting Award	2020	no genre	career	50000.0	
 698	Emily Rosko	Emily	Rosko	Q27942270	Emily Rosko	60954181	n2005061781	female	Cornell University, Stanford University	graduate	Cornell University		Stegner	winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2002	poetry	career	25800.0	
@@ -6192,9 +6192,9 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 642	Edwidge Danticat	Edwidge	Danticat	Q450346	Edwidge Danticat	32104515	n93100617	female	Barnard College, Brown University	graduate	Brown University			winner	MacArthur Foundation	MacArthur Fellowship	2009	no genre	career	500000.0	
 642	Edwidge Danticat	Edwidge	Danticat	Q450346	Edwidge Danticat	32104515	n93100617	female	Barnard College, Brown University	graduate	Brown University			judge	PEN America	Saul Bellow Award For Achievement In American Fiction	2014	prose	career	25000.0	
 642	Edwidge Danticat	Edwidge	Danticat	Q450346	Edwidge Danticat	32104515	n93100617	female	Barnard College, Brown University	graduate	Brown University			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2020	no genre	career	50000.0	
-407	Clare Barron	Clare	Barron					female	Yale University	graduate	Brooklyn College			winner	Whiting Foundation	Whiting Award	2017	no genre	career	50000.0	
-166	Annie Baker	Annie	Baker					female		graduate	Brooklyn College			winner	American Academy of Arts and Letters	Arts and Letters Awards	2015	no genre	career	10000.0	
-166	Annie Baker	Annie	Baker					female		graduate	Brooklyn College			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2011	no genre	career	50000.0	
+407	Clare Barron	Clare	Barron	Q29019677	Clare Barron	239146094350300332691	no2016043822	female	Yale University	graduate	Brooklyn College			winner	Whiting Foundation	Whiting Award	2017	no genre	career	50000.0	
+166	Annie Baker	Annie	Baker	Q4769239	Annie Baker	108066255	no2010043328	female		graduate	Brooklyn College			winner	American Academy of Arts and Letters	Arts and Letters Awards	2015	no genre	career	10000.0	
+166	Annie Baker	Annie	Baker	Q4769239	Annie Baker	108066255	no2010043328	female		graduate	Brooklyn College			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2011	no genre	career	50000.0	
 1083	Joan Larkin	Joan	Larkin	Q13563279	Joan Larkin	35770293	n81023252	female		graduate	Brooklyn College			winner	Academy of American Poets	Academy of American Poets Fellowship	2011	poetry	career	25000.0	
 1936	Rilla Askew	Rilla	Askew	Q7334284	Rilla Askew	13150160	n91105290	female		graduate	Brooklyn College			winner	American Academy of Arts and Letters	Arts and Letters Awards	2009	no genre	career	10000.0	
 2062	Sapphire Sapphire	Sapphire	Sapphire					female		graduate	Brooklyn College			winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2009	no genre	career	50000.0	
@@ -6426,7 +6426,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 83	Alicia Ostriker	Alicia	Ostriker	Q21623	Alicia Ostriker	79060171	n80139339	female		graduate				judge	Academy of American Poets	Wallace Stevens Award	2018	poetry	career	100000.0	
 83	Alicia Ostriker	Alicia	Ostriker	Q21623	Alicia Ostriker	79060171	n80139339	female		graduate				judge	Academy of American Poets	Wallace Stevens Award	2017	poetry	career	100000.0	
 83	Alicia Ostriker	Alicia	Ostriker	Q21623	Alicia Ostriker	79060171	n80139339	female		graduate				judge	Academy of American Poets	Wallace Stevens Award	2016	poetry	career	100000.0	
-86	Alison Rollins	Alison	Rollins					female		graduate				winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2016	poetry	career	25800.0	
+86	Alison Rollins	Alison	Rollins	Q56285064	Alison C. Rollins	15153470792345080171	n2018047739	female		graduate				winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	2016	poetry	career	25800.0	
 96	Allison Glock	Allison	Glock	Q4732751	Allison Glock	65829676	n2002041005	female		graduate				winner	Whiting Foundation	Whiting Award	2004	no genre	career	50000.0	
 141	Ann Beattie	Ann	Beattie	Q452145	Ann Beattie	78747728	n79141242	female		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1980	no genre	career	10000.0	
 148	Ann Pancake	Ann	Pancake	Q4766602	Ann Pancake	48570273	n2001029904	female		graduate				winner	Whiting Foundation	Whiting Award	2003	no genre	career	50000.0	
@@ -6458,7 +6458,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 586	Don Mee Choi	Don Mee	Choi	Q20880969	Don Mee Choi	523160483611104990799	no2006053846	female		graduate				winner	Lannan Foundation	Lannan Fellowship	2016	poetry	career	50000.0	
 586	Don Mee Choi	Don Mee	Choi	Q20880969	Don Mee Choi	523160483611104990799	no2006053846	female		graduate				winner	Whiting Foundation	Whiting Award	2011	no genre	career	50000.0	
 606	Dorothy Baker	Dorothy	Baker	Q5298302	Dorothy Baker	48211086	n85274412	female		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1964	no genre	career	10000.0	
-608	Dorothy Hughes	Dorothy	Hughes					female		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1973	no genre	career	10000.0	
+608	Dorothy Hughes	Dorothy	Hughes	Q1778440	Dorothy B. Hughes	22143303	n88619429	female		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1973	no genre	career	10000.0	
 651	Elaine Scarry	Elaine	Scarry					female		graduate				winner	American Academy of Arts and Letters	Morton Dauwen Zabel Award	2018	prose	career	10000.0	
 658	Eleanor Ross Taylor	Eleanor Ross	Taylor	Q5354381	Eleanor Ross Taylor	27194788	n82224037	female		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1968	no genre	career	10000.0	
 658	Eleanor Ross Taylor	Eleanor Ross	Taylor	Q5354381	Eleanor Ross Taylor	27194788	n82224037	female		graduate				winner	Poetry Foundation	Ruth Lilly Poetry Prize	2010	poetry	career	100000.0	
@@ -6500,9 +6500,9 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1088	Joann Beard	Joann	Beard					female		graduate				winner	Whiting Foundation	Whiting Award	1997	no genre	career	50000.0	
 1226	Josephine Miles	Josephine	Miles	Q6288420	Josephine Miles	110624639	n79079250	female		graduate				winner	Academy of American Poets	Academy of American Poets Fellowship	1978	poetry	career	25000.0	
 1226	Josephine Miles	Josephine	Miles	Q6288420	Josephine Miles	110624639	n79079250	female		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1956	no genre	career	10000.0	
-1233	Joyce Carol Oates	Joyce Carol	Oates	Q217557	Joyce Carol Oates	108187427	n86129758	female		graduate				winner	Tulsa Library Trust	Helmerich Distinguished Author Award	2002	prose	career	40000.0	
-1233	Joyce Carol Oates	Joyce Carol	Oates	Q217557	Joyce Carol Oates	7662418	n78095538	female		graduate				judge	New Literary Project (University of California, Berkeley and Lafayette Library)	Joyce Carol Oates Literary Prize/Simpson Family	2017	prose	career	50000.0	
+1233	Joyce Carol Oates	Joyce Carol	Oates	Q217557	Joyce Carol Oates	7662418	n87851370	female		graduate				winner	Tulsa Library Trust	Helmerich Distinguished Author Award	2002	prose	career	40000.0	
 1233	Joyce Carol Oates	Joyce Carol	Oates	Q217557	Joyce Carol Oates	7662418	n87851370	female		graduate				judge	New Literary Project (University of California, Berkeley and Lafayette Library)	Joyce Carol Oates Literary Prize/Simpson Family	2017	prose	career	50000.0	
+1233	Joyce Carol Oates	Joyce Carol	Oates	Q217557	Joyce Carol Oates	108187427	n87851370	female		graduate				judge	New Literary Project (University of California, Berkeley and Lafayette Library)	Joyce Carol Oates Literary Prize/Simpson Family	2017	prose	career	50000.0	
 1235	Judith Ortiz Cofer	Judith	Ortiz Cofer	Q6303597	Judith Ortiz Cofer	115049765	n87943894	female		graduate				judge	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2010	no genre	career	50000.0	
 1239	Judy Troy	Judy	Troy	Q6304630	Judy Troy	65365857	n82205428	female		graduate				winner	Whiting Foundation	Whiting Award	1996	no genre	career	50000.0	
 1242	Julia Randall	Julia	Randall	Q15506082	Julia Randall	5004776	n90626867	female		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1968	no genre	career	10000.0	
@@ -6585,10 +6585,10 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 2043	Sally Rooney	Sally	Rooney	Q54861296	Sally Rooney	49149912708206212971	no2017108521	female		graduate				winner	American Academy of Arts and Letters	E. M. Forster Award	2019	no genre	career	10000.0	
 2054	Sandra Benitez	Sandra	Benitez	Q7416543	Sandra Benitez	117628163	n93047741	female		graduate				winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2006	no genre	career	50000.0	
 2066	Sarah Hall	Sarah	Hall	Q3473359	Sarah Hall	74094805	no2002084638	female		graduate				winner	American Academy of Arts and Letters	E. M. Forster Award	2014	no genre	career	10000.0	
-2069	Sarah M. Broom	Sarah M.	Broom	Q66459255	Sarah M. Broom	44155707008222410304	n2019021809	female		graduate				winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2020	no genre	career	50000.0	
+2069	Sarah M. Broom	Sarah M.	Broom	Q61803270	Sarah Broom	19090677	n2005049371	female		graduate				winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2020	no genre	career	50000.0	
 2072	Saskia Hamilton	Saskia	Hamilton	Q7425699	Saskia Hamilton	58421732	n2001029229	female		graduate				winner	Poetry Foundation	Ruth Lilly And Dorothy Sargent Rosenberg Poetry Fellowship	1989	poetry	career	15000.0	
 2089	Shanti Ariker	Shanti	Ariker					female		graduate				judge	New Literary Project (University of California, Berkeley and Lafayette Library)	Joyce Carol Oates Literary Prize/Simpson Family	2017	prose	career	50000.0	
-2091	Sharon Cameron	Sharon	Cameron	Q112561895	Sharon Cameron	223798671		female		graduate				winner	American Academy of Arts and Letters	Harold D. Vursell Memorial Award	2009	prose	career	20000.0	
+2091	Sharon Cameron	Sharon	Cameron	Q112561895	Sharon Cameron	223798671	n2012001555	female		graduate				winner	American Academy of Arts and Letters	Harold D. Vursell Memorial Award	2009	prose	career	20000.0	
 2105	Shirley Graham	Shirley	Graham	Q3482354	Shirley Graham Du Bois	86434093	n86130395	female		graduate				winner	American Academy of Arts and Letters	Arts and Letters Awards	1950	no genre	career	10000.0	
 2112	Sinéad Morrissey	Sinéad	Morrissey	Q7525265	Sinéad Morrissey	84238223	no96030017	female		graduate				winner	American Academy of Arts and Letters	E. M. Forster Award	2016	no genre	career	10000.0	
 2112	Sinéad Morrissey	Sinéad	Morrissey	Q7525265	Sinéad Morrissey	84238223	no96030017	female		graduate				winner	Lannan Foundation	Lannan Fellowship	2007	poetry	career	50000.0	
@@ -6780,7 +6780,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 122	Andrea Barrett	Andrea	Barrett	Q49065	Andrea Barrett	79163089	n82224071	female						winner	American Academy of Arts and Letters	Arts and Letters Awards	2003	no genre	career	10000.0	
 122	Andrea Barrett	Andrea	Barrett	Q49065	Andrea Barrett	79163089	n82224071	female						winner	MacArthur Foundation	MacArthur Fellowship	2001	no genre	career	500000.0	
 134	Angela Johnson	Angela	Johnson	Q4762469	Angela Johnson	28265992	n2002022484	female						winner	MacArthur Foundation	MacArthur Fellowship	2003	no genre	career	500000.0	
-142	Ann Cornelisen	Ann	Cornelisen					female						winner	American Academy of Arts and Letters	Arts and Letters Awards	1974	no genre	career	10000.0	
+142	Ann Cornelisen	Ann	Cornelisen	Q63485996	Anne Cornelisen	110107430	n50020425	female						winner	American Academy of Arts and Letters	Arts and Letters Awards	1974	no genre	career	10000.0	
 144	Ann Goldstein	Ann	Goldstein					female						winner	American Academy of Arts and Letters	Arts and Letters Awards	2015	no genre	career	10000.0	
 146	Ann Lauterbach	Ann	Lauterbach	Q4766499	Ann Lauterbach	22164048	n78090917	female						winner	MacArthur Foundation	MacArthur Fellowship	1993	no genre	career	500000.0	
 162	Anne Tyler	Anne	Tyler	Q235615	Anne Tyler	39384885	n79100453	female						judge	American Academy of Arts and Letters	Arthur Rense Prize	2017	poetry	career	20000.0	
@@ -6841,7 +6841,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 570	Denise Levertov	Denise	Levertov	Q272042	Denise Levertov	9868894	n50049988	female						winner	Lannan Foundation	Lannan Award	1993	poetry	career	150000.0	
 577	Diane Johnson	Diane	Johnson	Q533343	Diane Johnson	44322506	n97094021	female						winner	American Academy of Arts and Letters	Mildred And Harold Strauss Livings	1988	prose	career	100000.0	
 578	Diane Wakoski	Diane	Wakoski	Q1209000	Diane Wakoski	79051243	n79088987	female						judge	Yale University	Bollingen Prize for Poetry	1977	poetry	career	10000.0	
-583	Dominique Morisseau	Dominique	Morisseau					female						winner	American Academy of Arts and Letters	Arts and Letters Awards	2017	no genre	career	10000.0	
+583	Dominique Morisseau	Dominique	Morisseau	Q27898965	Dominique Morisseau	294085931	n2012077955	female						winner	American Academy of Arts and Letters	Arts and Letters Awards	2017	no genre	career	10000.0	
 603	Doris Betts	Doris	Betts	Q5297898	Doris Betts	25425326	n81035731	female						winner	American Academy of Arts and Letters	Award of Merit Medal in the Short Story	1989	prose	career	25000.0	
 619	Eavan Boland	Eavan	Boland	Q5331464	Eavan Boland	22253909	n80109150	female						winner	Lannan Foundation	Lannan Award	1994	poetry	career	150000.0	
 619	Eavan Boland	Eavan	Boland	Q5331464	Eavan Boland	22253909	n80109150	female						judge	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2007	no genre	career	50000.0	
@@ -6889,7 +6889,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 842	Gwendolyn Brooks	Gwendolyn	Brooks	Q270715	Gwendolyn Brooks	113723435	n50041281	female						winner	Library of Congress	Poet Laureate	1986	poetry	career	35000.0	
 842	Gwendolyn Brooks	Gwendolyn	Brooks	Q270715	Gwendolyn Brooks	113723435	n50041281	female						winner	Library of Congress	Poet Laureate	1985	poetry	career	35000.0	
 855	Hanya Yanagihara	Hanya	Yanagihara	Q20902324	Hanya Yanagihara	37146634453341931978	nb2001075052	female						winner	American Academy of Arts and Letters	Benjamin H. Danks Award	2020	no genre	career	20000.0	
-873	Heidi Schreck	Heidi	Schreck					female						winner	American Academy of Arts and Letters	Benjamin H. Danks Award	2019	no genre	career	20000.0	
+873	Heidi Schreck	Heidi	Schreck	Q28007214	Heidi Schreck			female						winner	American Academy of Arts and Letters	Benjamin H. Danks Award	2019	no genre	career	20000.0	
 876	Helen Simpson	Helen	Simpson	Q910123	Helen Simpson	56663664	nr96010411	female						winner	American Academy of Arts and Letters	E. M. Forster Award	2002	no genre	career	10000.0	
 895	Hilary Mantel	Hilary	Mantel	Q465700	Hilary Mantel	44415775	n87901027	female						winner	Tulsa Library Trust	Helmerich Distinguished Author Award	2018	prose	career	40000.0	
 897	Hildad Doolittle	Hildad	Doolittle					female						winner	American Academy of Arts and Letters	Award of Merit Medal in Poetry	1960	poetry	career	25000.0	
@@ -6903,7 +6903,7 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1051	Jennifer Nansubugamakumbi	Jennifer	Nansubugamakumbi					female						winner	Yale University	Windham Campbell Prize	2018	prose	career	165000.0	
 1080	Joan Chase	Joan	Chase	Q6204941	Joan Chase	79052983	n82162353	female						winner	Whiting Foundation	Whiting Award	1987	no genre	career	50000.0	
 1081	Joan Didion	Joan	Didion	Q267691	Joan Didion	100261335	n78089822	female						winner	American Academy of Arts and Letters	Morton Dauwen Zabel Award	1978	prose	career	10000.0	
-1086	Joan Williams	Joan	Williams					female						winner	American Academy of Arts and Letters	Arts and Letters Awards	1962	no genre	career	10000.0	
+1086	Joan Williams	Joan	Williams	Q55647989	Joan Williams	115905367	n81110415	female						winner	American Academy of Arts and Letters	Arts and Letters Awards	1962	no genre	career	10000.0	
 1222	Josephine Herbst	Josephine	Herbst	Q6288380	Josephine Herbst	93008242	n50068741	female						winner	American Academy of Arts and Letters	Arts and Letters Awards	1966	no genre	career	10000.0	
 1224	Josephine Jacobsen	Josephine	Jacobsen	Q6288385	Josephine Jacobsen	17268228	n50027989	female						winner	Academy of American Poets	Academy of American Poets Fellowship	1987	poetry	career	25000.0	
 1224	Josephine Jacobsen	Josephine	Jacobsen	Q6288385	Josephine Jacobsen	17268228	n50027989	female						winner	American Academy of Arts and Letters	Arts and Letters Awards	1982	no genre	career	10000.0	
@@ -6923,11 +6923,11 @@ person_id	full_name	given_name	last_name	author_wikidata	author_wikidata_label	a
 1323	Killarney Clary	Killarney	Clary	Q16186189	Killarney Clary			female						winner	Lannan Foundation	Lannan Award	1992	poetry	career	150000.0	
 1328	Kirsten Bakis	Kirsten	Bakis	Q2900671	Kirsten Bakis	50048483	n96058180	female						winner	Whiting Foundation	Whiting Award	2004	no genre	career	50000.0	
 1367	Le Thi Diem Thuy	Le Thi Diem	Thuy	Q6507753	Lê Thị Diễm Thúy	79507735	n2002041809	female						winner	United States Artists (Ford, Rockefeller, Rasmuson, and Prudential)	USA Fellowship	2008	no genre	career	50000.0	
-1372	Lee Smith	Lee	Smith	Q13563113	Lee Smith	54950342	n80070525	female						winner	American Academy of Arts and Letters	Arts and Letters Awards	1999	no genre	career	10000.0	
+1372	Lee Smith	Lee	Smith	Q6515097	Lee Smith	83499931	n2009018497	female						winner	American Academy of Arts and Letters	Arts and Letters Awards	1999	no genre	career	10000.0	
 1379	Leonora Speyer	Leonora	Speyer	Q1547340	Leonora Speyer	170679717	n87870746	female						judge	Academy of American Poets	Academy of American Poets Fellowship	1950	poetry	career	25000.0	
 1379	Leonora Speyer	Leonora	Speyer	Q1547340	Leonora Speyer	170679717	n87870746	female						judge	Academy of American Poets	Academy of American Poets Fellowship	1949	poetry	career	25000.0	
 1379	Leonora Speyer	Leonora	Speyer	Q1547340	Leonora Speyer	170679717	n87870746	female						judge	Academy of American Poets	Academy of American Poets Fellowship	1948	poetry	career	25000.0	
-1380	Leopoldine Core	Leopoldine	Core	Q77238949	Leopoldine Core	317120413		female						winner	Whiting Foundation	Whiting Award	2015	no genre	career	50000.0	
+1380	Leopoldine Core	Leopoldine	Core	Q77238949	Leopoldine Core	317120413	no2015116279	female						winner	Whiting Foundation	Whiting Award	2015	no genre	career	50000.0	
 1387	Leslie Marmon Silko	Leslie Marmon	Silko	Q273001	Leslie Marmon Silko	41868880	n80093635	female	None	None	None	None	None	winner	American Academy of Arts and Letters	Arts and Letters Awards	2011	no genre	career	10000.0	None
 1387	Leslie Marmon Silko	Leslie Marmon	Silko	Q273001	Leslie Marmon Silko	41868880	n80093635	female	None	None	None	None	None	winner	American Academy of Arts and Letters	Christopher Lightfoot Walker Award	2020	no genre	career	100000.0	None
 1387	Leslie Marmon Silko	Leslie Marmon	Silko	Q273001	Leslie Marmon Silko	41868880	n80093635	female	None	None	None	None	None	winner	Lannan Foundation	Lannan Award	2000	prose	career	150000.0	None


### PR DESCRIPTION
Changed search API on wikidata to have a fuzzier search to narrow down allowed for more hits:

Award file stats:
Number of rows with one identifier populated: 6386 out of  7133 - 89.5%
